### PR TITLE
Fix: Open external link in new tab (Issue #937)

### DIFF
--- a/packages/frontend/src/components/About.tsx
+++ b/packages/frontend/src/components/About.tsx
@@ -41,7 +41,7 @@ const About = () => {
           sx={{ maxWidth: 800 }}
         >
           {t('about.contributors').map(({github_user_name, github_image_id}) => (
-            <a href={`https://github.com/${github_user_name}`} aria-label={`${github_user_name} github profile`} key={github_user_name}>
+            <a href={`https://github.com/${github_user_name}`} target = "_blank" aria-label={`${github_user_name} github profile`} key={github_user_name}>
               <Box
                 component="img"
                 src={`https://avatars.githubusercontent.com/u/${github_image_id}?v=4`}
@@ -62,7 +62,10 @@ const About = () => {
           {t('about.donate_description')}
         </Typography>
 
-        <PrimaryButton sx={{m: 3}} href={t('about.donate_link')}>
+        <PrimaryButton 
+          sx={{m: 3}}
+          href={t('about.donate_link')}
+        >
           {t('about.donate_button')}
         </PrimaryButton>
       </Paper>

--- a/packages/frontend/src/components/Footer.tsx
+++ b/packages/frontend/src/components/Footer.tsx
@@ -42,6 +42,7 @@ export default function Footer() {
             <br/>
 						<Link
 							href="https://www.starvoting.org/"
+							target = "_blank"
 							sx={{
 								color: 'var(--brand-pop)',
 								textDecoration: 'underline',
@@ -53,6 +54,7 @@ export default function Footer() {
             <Tooltip title="Equal Vote Coalition" arrow placement="top">
               <Link
                 href="https://www.equal.vote/"
+				target = "_blank"
                 sx={{ 
                   color: 'var(--brand-pop)',
                   textDecoration: 'underline',
@@ -94,6 +96,7 @@ export default function Footer() {
 							component="img"
 							alt="Equal Vote Coalition Logo"
 							src="https://assets.nationbuilder.com/unifiedprimary/sites/1/meta_images/original/evc_logo.png?1730324377"
+							
 							sx={{
 								width: '100%',
 								padding: 2,
@@ -127,6 +130,7 @@ export default function Footer() {
 							<Link
 								aria-label="STAR Voting Facebook page"
 								href="https://www.facebook.com/STARVoting"
+								target = "_blank"
 								color="inherit"
 								sx={{ pl: 1, pr: 1 }}
 							>
@@ -135,6 +139,7 @@ export default function Footer() {
 							<Link
 								aria-label="STAR Voting Instagram page"
 								href="https://www.instagram.com/starvoting/"
+								target = "_blank"
 								color="inherit"
 								sx={{ pl: 1, pr: 1 }}
 							>
@@ -143,6 +148,7 @@ export default function Footer() {
 							<Link
 								aria-label="STAR Voting X page"
 								href="https://twitter.com/5starvoting"
+								target = "_blank"
 								color="inherit"
 								sx={{ pl: 1, pr: 1 }}
 							>
@@ -151,6 +157,7 @@ export default function Footer() {
 							<Link
 								aria-label="Equal Vote GitHub"
 								href="https://github.com/Equal-Vote"
+								target = "_blank"
 								color="inherit"
 								sx={{ pl: 1, pr: 1 }}
 							>


### PR DESCRIPTION
## Description
This PR fixes the issue where the Link in footer and About page open in same tab.

## Screenshots / Videos (frontend only) 
Video of footer

https://www.loom.com/share/b6eaffdedb6646a8a9ce1365681d4a02?sid=3dc07305-01a1-4e8d-82e6-bd7f586b732b Be sure to include both desktop and mobile views (mobile could be as low as 320 px wide) 

🔗 Related Issue
Closes #937
