### PR TITLE
fix(frontend): Scroll to top on page transitions

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import PublicArchive from './components/Elections/PublicArchive'
 import NameMatchingTester from './components/NameMatchingTester'
 import StyleGuide from './components/StyleGuide'
 import { PrimaryButton } from './components/styles'
+import ScrollToTop from './hooks/scrollToTop'
 
 const App = () => {
   const {t} = useSubstitutedTranslation();
@@ -45,6 +46,7 @@ const App = () => {
   }
   return (
     <Router>
+      <ScrollToTop/>
       <ComposeContextProviders providers={[
         FeatureFlagContextProvider,
         ThemeContextProvider,

--- a/packages/frontend/src/hooks/scrollToTop.ts
+++ b/packages/frontend/src/hooks/scrollToTop.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};


### PR DESCRIPTION
## Description
Currently, react is sometimes persisting previous scroll position across page re-routes (example: transitioning from ballot submission to thank you page).

## Screenshots / Videos (frontend only) 
Before fix:
https://github.com/user-attachments/assets/124943d1-de89-4a97-9127-8948faa0585c

After fix:
https://github.com/user-attachments/assets/6c44db8f-bb28-4812-8c13-53d07f78e958



## Related Issues
fixes #900 
https://github.com/Equal-Vote/bettervoting/issues/900