### PR TITLE
add: "share" icon on the Share Election button

### DIFF
--- a/packages/frontend/src/components/Election/ShareButton.tsx
+++ b/packages/frontend/src/components/Election/ShareButton.tsx
@@ -12,6 +12,7 @@ import { SecondaryButton } from "../styles";
 import useSnackbar from "../SnackbarContext";
 import { useSubstitutedTranslation } from "../util";
 import { useState } from "react"
+import IosShareIcon from '@mui/icons-material/IosShare';
 
 export default function ShareButton({ url }: { url: string }) {
     const { setSnack } = useSnackbar()
@@ -75,6 +76,7 @@ export default function ShareButton({ url }: { url: string }) {
                 fullWidth
                 onClick={handleOpenNavMenu}>
                 {t('share.button')}
+                <IosShareIcon sx={{pl: 1}} />
             </SecondaryButton>
             <Fade timeout={350}>
                 <Paper >


### PR DESCRIPTION
## Description
Adds a share icon next to the Share Election button when creating an election

## Screenshots / Videos (frontend only) 
![Screenshot 2025-06-19 162710](https://github.com/user-attachments/assets/78aa5d28-b314-4977-ae90-d01625394352)

## Related Issues
Fixes #839 