### PR TITLE
Fixing #745 I eliminated the "continue" button

### DIFF
--- a/packages/frontend/src/components/Election/Voting/GenericBallotView/CandidateLabel.tsx
+++ b/packages/frontend/src/components/Election/Voting/GenericBallotView/CandidateLabel.tsx
@@ -2,22 +2,22 @@ import { Box, Link, Typography } from '@mui/material';
 import { Candidate } from '@equal-vote/star-vote-shared/domain_model/Candidate';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 interface CandidateLabelProps {
-    candidate: Candidate;
-    gridArea: string;
+  candidate: Candidate;
+  gridArea: string;
 }
-export default function CandidateLabel ({candidate, gridArea}: CandidateLabelProps) {
-    return (
-        <Box
-         sx={{
-            gridArea: gridArea
-          }}>
-            <Typography className="rowHeading" align='left' variant="h6" component="h6" sx={{
-              wordwrap: "break-word",
-              mx: '10px',
-            }}>
-              {candidate.candidate_url && <Link href={candidate.candidate_url} target='_blank'>{candidate.candidate_name}<OpenInNewIcon sx={{height: 15}}/></Link>}
-              {!candidate.candidate_url && candidate.candidate_name}
-            </Typography>
-          </Box>
-    );
+export default function CandidateLabel({ candidate, gridArea }: CandidateLabelProps) {
+  return (
+    <Box
+      sx={{
+        gridArea: gridArea
+      }}>
+      <Typography className="rowHeading" align='left' variant="h6" component="h6" sx={{
+        wordBreak: "break-word",
+        mx: '10px',
+      }}>
+        {candidate.candidate_url && <Link href={candidate.candidate_url} target='_blank'>{candidate.candidate_name}<OpenInNewIcon sx={{ height: 15 }} /></Link>}
+        {!candidate.candidate_url && candidate.candidate_name}
+      </Typography>
+    </Box>
+  );
 }

--- a/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
+++ b/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
@@ -320,6 +320,7 @@ const CreateElectionDialog = () => {
                                         })
                                     }
                                     variant='standard'
+                                    fullWidth
                                     sx={{ mt: -1, display: 'block' }}
                                 />}
                                 label={t(`election_settings.contact_email`)}

--- a/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
+++ b/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
@@ -12,31 +12,31 @@ import { useNavigate } from "react-router";
 import { TimeZone } from "@equal-vote/star-vote-shared/domain_model/Util";
 
 /////// PROVIDER SETUP /////
-export interface ICreateElectionContext{
+export interface ICreateElectionContext {
     open: boolean
     quickPoll: NewElection
-    openDialog: (quickPoll?:NewElection) => void
+    openDialog: (quickPoll?: NewElection) => void
     closeDialog: () => void
 }
 
 export const CreateElectionContext = createContext<ICreateElectionContext>(null);
 
-export const CreateElectionContextProvider = ({children}: {children: ReactNode}) => {
+export const CreateElectionContextProvider = ({ children }: { children: ReactNode }) => {
     const [open, setOpen] = useState(false);
     const [quickPoll, setQuickPoll] = useState(undefined);
 
-    const openDialog = (quickPoll:NewElection = undefined) =>{
+    const openDialog = (quickPoll: NewElection = undefined) => {
         setQuickPoll(quickPoll);
         setOpen(true);
     }
 
-    const closeDialog = () =>{
+    const closeDialog = () => {
         setQuickPoll(undefined);
         setOpen(false);
     }
 
     return <CreateElectionContext.Provider
-        value={{open, quickPoll, openDialog, closeDialog}}
+        value={{ open, quickPoll, openDialog, closeDialog }}
     >
         {children}
     </CreateElectionContext.Provider>
@@ -70,7 +70,7 @@ export const defaultElection: NewElection = {
 }
 
 const templateMappers = {
-    'demo': (election:NewElection):NewElection => ({
+    'demo': (election: NewElection): NewElection => ({
         ...election,
     }),
     /*'public': (election:NewElection):NewElection => ({
@@ -84,7 +84,7 @@ const templateMappers = {
             },
         }
     }),*/
-    'unlisted': (election:NewElection):NewElection => ({
+    'unlisted': (election: NewElection): NewElection => ({
         ...election,
         is_public: false,
         settings: {
@@ -103,7 +103,7 @@ const templateMappers = {
             voter_authentication: {
                 ...election.settings.voter_authentication,
                 // email: true <- this means login will be required, that's not what we want for this setting. TODO: figure out refactored name
-                voter_id: true 
+                voter_id: true
             },
             invitation: 'email',
         }
@@ -121,10 +121,10 @@ const templateMappers = {
     }),
 }
 
-const StepButtons = ({activeStep, setActiveStep, canContinue}: { activeStep: number, setActiveStep: React.Dispatch<React.SetStateAction<number>>, canContinue: boolean }) => <>
+const StepButtons = ({ activeStep, setActiveStep, canContinue }: { activeStep: number, setActiveStep: React.Dispatch<React.SetStateAction<number>>, canContinue: boolean }) => <>
     {activeStep > 0 &&
         <SecondaryButton
-            onClick={() => setActiveStep(i => i-1)}
+            onClick={() => setActiveStep(i => i - 1)}
             sx={{ mt: 1, mr: 1 }}
         >
             Back
@@ -135,7 +135,7 @@ const StepButtons = ({activeStep, setActiveStep, canContinue}: { activeStep: num
             fullWidth={false}
             variant="contained"
             disabled={!canContinue}
-            onClick={() => setActiveStep(i => i+1)}
+            onClick={() => setActiveStep(i => i + 1)}
             sx={{ mt: 1, mr: 1 }}
         >
             Continue
@@ -153,7 +153,7 @@ const CreateElectionDialog = () => {
         createElectionContext.closeDialog();
     };
 
-    const [errors, setErrors] = useState({title: ''});
+    const [errors, setErrors] = useState({ title: '' });
 
     const [election, setElection] = useState(defaultElection);
 
@@ -166,7 +166,7 @@ const CreateElectionDialog = () => {
 
     useEffect(() => {
         const q = createElectionContext.quickPoll;
-        if(!createElectionContext.quickPoll) return;
+        if (!createElectionContext.quickPoll) return;
 
         // quick poll also specifies a number of other settings but we're not keeping those, we're only keeping the information that the user specified
         setElection({
@@ -179,7 +179,7 @@ const CreateElectionDialog = () => {
                     candidates: q.races[0].candidates.filter(candidate => candidate.candidate_name.length > 0)
                 }
             ]
-        }) 
+        })
     }, [createElectionContext.quickPoll])
 
     const onAddElection = async (election) => {
@@ -189,7 +189,7 @@ const CreateElectionDialog = () => {
         const newElection = await postElection({
             Election: election,
         })
-        if (!newElection)  throw Error("Error submitting election");
+        if (!newElection) throw Error("Error submitting election");
 
         navigate(`/${newElection.election.election_id}/admin`)
         onClose()
@@ -216,31 +216,33 @@ const CreateElectionDialog = () => {
             <Stepper activeStep={activeStep} orientation="vertical">
                 <Step>
                     <StepLabel>{t('election_creation.term_title')} <strong>{
-                        election.settings.term_type === undefined? '' : capitalize(t(`keyword.${election.settings.term_type}.election`))
+                        election.settings.term_type === undefined ? '' : capitalize(t(`keyword.${election.settings.term_type}.election`))
                     }</strong></StepLabel>
                     <StepContent>
                         <Typography>{t('election_creation.term_question')}
-                            <Tip name='polls_vs_elections'/>
+                            <Tip name='polls_vs_elections' />
                         </Typography>
                         <RadioGroup row>
-                            {['poll', 'election'].map( (type, i) => 
+                            {['poll', 'election'].map((type, i) =>
                                 <FormControlLabel
                                     key={i}
                                     value={capitalize(t(`keyword.${type}.election`))}
-                                    control={<Radio/>}
+                                    control={<Radio />}
                                     label={capitalize(t(`keyword.${type}.election`))}
-                                    onClick={() => setElection({
-                                        ...election,
-                                        settings: {
-                                            ...election.settings,
-                                            term_type: type as TermType
-                                        }
-                                    })}
+                                    onClick={() => {
+                                        setElection({
+                                            ...election,
+                                            settings: {
+                                                ...election.settings,
+                                                term_type: type as TermType
+                                            }
+                                        });
+                                        setTimeout(() => setActiveStep(1), 250);
+                                    }}
                                     checked={election.settings.term_type === type}
                                 />
                             )}
                         </RadioGroup>
-                        <StepButtons activeStep={0} setActiveStep={setActiveStep} canContinue={election.settings.term_type !== undefined}/>
                     </StepContent>
                 </Step>
                 <Step>
@@ -251,18 +253,18 @@ const CreateElectionDialog = () => {
                             termType={election.settings.term_type}
                             value={election.title}
                             onUpdateValue={
-                                (value) => setElection({...election, title: value})
+                                (value) => setElection({ ...election, title: value })
                             }
                             errors={errors}
                             setErrors={setErrors}
                             showLabel={false}
                         />
-                        <StepButtons activeStep={1} setActiveStep={setActiveStep} canContinue={/^[^\s][a-zA-Z0-9\s]{3,49}$/.test(election.title) && errors.title == ''}/>
+                        <StepButtons activeStep={1} setActiveStep={setActiveStep} canContinue={/^[^\s][a-zA-Z0-9\s]{3,49}$/.test(election.title) && errors.title == ''} />
                     </StepContent>
                 </Step>
                 <Step>
                     <StepLabel>{t('election_creation.restricted_title')} <strong>
-                        {election.settings.voter_access !== undefined && t(`keyword.${election.settings.voter_access === 'closed'? 'yes' : 'no'}`)}
+                        {election.settings.voter_access !== undefined && t(`keyword.${election.settings.voter_access === 'closed' ? 'yes' : 'no'}`)}
                     </strong></StepLabel>
                     <StepContent>
                         <Typography>
@@ -270,31 +272,33 @@ const CreateElectionDialog = () => {
                         </Typography>
 
                         <RadioGroup row>
-                            {[true, false].map( (restricted, i) => 
+                            {[true, false].map((restricted, i) =>
                                 <FormControlLabel
                                     key={i}
                                     value={restricted}
-                                    control={<Radio/>}
-                                    label={t(`keyword.${restricted? 'yes' : 'no'}`)}
+                                    control={<Radio />}
+                                    label={t(`keyword.${restricted ? 'yes' : 'no'}`)}
                                     onClick={() => {
-                                        setElection({...election, settings: {
-                                            ...election.settings,
-                                            voter_access: restricted? 'closed' : 'open',
-                                            contact_email: restricted? (
-                                                (election.settings.contact_email != undefined && election.settings.contact_email != '')?
-                                                    election.settings.contact_email : authSession.getIdField('email')
-                                            ): ''
-                                        }})
+                                        setElection({
+                                            ...election, settings: {
+                                                ...election.settings,
+                                                voter_access: restricted ? 'closed' : 'open',
+                                                contact_email: restricted ? (
+                                                    (election.settings.contact_email != undefined && election.settings.contact_email != '') ?
+                                                        election.settings.contact_email : authSession.getIdField('email')
+                                                ) : ''
+                                            }
+                                        })
                                     }}
-                                    checked={election.settings.voter_access === (restricted? 'closed' : 'open')}
+                                    checked={election.settings.voter_access === (restricted ? 'closed' : 'open')}
                                 />
                             )}
                         </RadioGroup>
 
                         <Box sx={{
                             // 60px copied from unset, then added some for padding
-                            height: (election.settings.voter_access == 'closed'? '90px' : 0),
-                            opacity: (election.settings.voter_access == 'closed'? 1 : 0),
+                            height: (election.settings.voter_access == 'closed' ? '90px' : 0),
+                            opacity: (election.settings.voter_access == 'closed' ? 1 : 0),
                             transition: 'height .4s, opacity .7s',
                             overflow: 'hidden',
                             width: '100%',
@@ -307,14 +311,16 @@ const CreateElectionDialog = () => {
                                     id='contact_email'
                                     name='contact_email'
                                     value={election.settings.contact_email}
-                                    onChange={(e) => 
-                                        setElection({...election, settings: {
-                                            ...election.settings,
-                                            contact_email: e.target.value
-                                        }})
+                                    onChange={(e) =>
+                                        setElection({
+                                            ...election, settings: {
+                                                ...election.settings,
+                                                contact_email: e.target.value
+                                            }
+                                        })
                                     }
                                     variant='standard'
-                                    sx={{ mt: -1, display: 'block'}}
+                                    sx={{ mt: -1, display: 'block' }}
                                 />}
                                 label={t(`election_settings.contact_email`)}
                                 labelPlacement='top'
@@ -323,8 +329,8 @@ const CreateElectionDialog = () => {
                                 }}
                             />
                         </Box>
-                        
-                        <StepButtons activeStep={2} setActiveStep={setActiveStep} canContinue={election.settings.voter_access !== undefined}/>
+
+                        <StepButtons activeStep={2} setActiveStep={setActiveStep} canContinue={election.settings.voter_access !== undefined} />
                     </StepContent>
                 </Step>
                 <Step>
@@ -333,8 +339,8 @@ const CreateElectionDialog = () => {
                         <Typography>
                             {t('election_creation.template_prompt')}
                         </Typography>
-                        <Box style={{height: '10px'}}/> {/*hacky padding*/}
-                        {(election.settings.voter_access === 'closed'? ['email_list', 'id_list'] : ['demo', 'unlisted']).map((name) =>
+                        <Box style={{ height: '10px' }} /> {/*hacky padding*/}
+                        {(election.settings.voter_access === 'closed' ? ['email_list', 'id_list'] : ['demo', 'unlisted']).map((name) =>
                             <RowButtonWithArrow
                                 title={t(`election_creation.${name}_title`)}
                                 description={t(`election_creation.${name}_description`)}
@@ -344,7 +350,7 @@ const CreateElectionDialog = () => {
                             />
                         )}
 
-                        <StepButtons activeStep={3} setActiveStep={setActiveStep} canContinue={false}/>
+                        <StepButtons activeStep={3} setActiveStep={setActiveStep} canContinue={false} />
                     </StepContent>
                 </Step>
             </Stepper>


### PR DESCRIPTION
## Description

Issue #745 asked to eliminate the "continue" button on the first step when creating a New Election. @ArendPeter also suggested that I added like a quarter of a second to make the transition to next step smoother.

## Screenshots / Videos (frontend only) 

<img width="411" height="880" alt="Screenshot 2025-07-28 180851" src="https://github.com/user-attachments/assets/9ace36a5-76e3-4dac-b47e-5ba30e5865e5" />
<img width="1583" height="931" alt="Screenshot 2025-07-28 180804" src="https://github.com/user-attachments/assets/2716059e-df59-4d2b-9747-f36a81200bb2" />
