### PR TITLE
Add close/open election functionality

### DIFF
--- a/packages/backend/src/Controllers/Election/index.ts
+++ b/packages/backend/src/Controllers/Election/index.ts
@@ -9,5 +9,6 @@ export * from './getElectionResultsController';
 export * from './getElectionsController';
 export * from './sandboxController';
 export * from './sendInvitesController';
+export * from './setOpenStateController';
 export * from './setPublicResultsController';
 export * from './sendEmailController';

--- a/packages/backend/src/Controllers/Election/setOpenStateController.ts
+++ b/packages/backend/src/Controllers/Election/setOpenStateController.ts
@@ -1,0 +1,57 @@
+import ServiceLocator from '../../ServiceLocator';
+import Logger from '../../Services/Logging/Logger';
+import { permissions } from '@equal-vote/star-vote-shared/domain_model/permissions';
+import { expectPermission } from "../controllerUtils";
+import { BadRequest, InternalServerError } from "@curveball/http-errors";
+import { Election } from '@equal-vote/star-vote-shared/domain_model/Election';
+import { IElectionRequest } from "../../IRequest";
+import { Response, NextFunction } from 'express';
+
+var ElectionsModel = ServiceLocator.electionsDb();
+
+const className = "election.Controllers";
+
+const setOpenState = async (req: IElectionRequest, res: Response, next: NextFunction) => {
+    Logger.info(req, `${className}.archive ${req.election.election_id}`);
+    expectPermission(req.user_auth.roles, permissions.canEditElectionState)
+
+    const election: Election = req.election
+    const closing = req.body.closing
+
+    var msg = null
+    if (typeof closing !== 'boolean') {
+        msg = "closing setting not provided or incorrect type"
+    } else if (election.state !== 'closed' && election.state !== 'open') {
+        msg = "Cannot close/open an election that is not open or closed"
+    } else if (closing && election.state === 'closed') {
+        msg = "Cannot close an election that is already closed"
+    } else if (!closing && election.state === 'open') {
+        msg = "Cannot open an election that is already open"
+    }
+
+    if (msg) {
+        Logger.info(req, msg)
+        throw new BadRequest(msg)
+    }
+
+    var failMsg
+    if (closing) {
+        election.state = 'closed'
+        failMsg = "Failed to close election"
+    } else {
+        election.state = 'open'
+        failMsg = "Failed to open election"
+    }
+    
+    const updatedElection = await ElectionsModel.updateElection(req.election, req, `Open or close election`);
+    if (!updatedElection) {
+        Logger.info(req, failMsg);
+        throw new BadRequest(failMsg)
+    }
+
+    res.json({ election: updatedElection })
+}
+
+export {
+    setOpenState,
+}

--- a/packages/backend/src/OpenApi/swagger.json
+++ b/packages/backend/src/OpenApi/swagger.json
@@ -2991,7 +2991,6 @@
       "tieBreakType": {
         "enum": [
           "five_star",
-          "head_to_head",
           "none",
           "random",
           "score"
@@ -3944,6 +3943,62 @@
         "responses": {
           "200": {
             "description": "Election archived",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "election": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/Election"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Election not found"
+          }
+        }
+      }
+    },
+    "/Election/{id}/setOpenState": {
+      "post": {
+        "summary": "Change an election's state from open to closed, or from closed to open",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "tags": [
+          "Elections"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The election ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "name": "closing",
+              "schema": {
+                "type": "boolean"
+              },
+              "description": "True if closing an open election; false if reopening a closed election"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Election state changed",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/backend/src/Routes/elections.routes.ts
+++ b/packages/backend/src/Routes/elections.routes.ts
@@ -19,6 +19,7 @@ import {
     getSandboxResults,
     sendInvitationController,
     sendInvitationsController,
+    setOpenState,
     setPublicResults,
     sendEmailsController,
 } from '../Controllers/Election';
@@ -437,6 +438,44 @@ electionsRouter.post('/Election/:id/setPublicResults',asyncHandler(setPublicResu
  *         description: Election not found 
 */
 electionsRouter.post('/Election/:id/archive', asyncHandler(archiveElection))
+
+ /** 
+ * @swagger
+ * /Election/{id}/setOpenState:
+ *   post:
+ *     summary: Change an election's state from open to closed, or from closed to open
+ *     security:
+ *      - ApiKeyAuth: []
+ *     tags: [Elections]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The election ID
+ *     requestBody:
+ *      content:
+ *        application/json:
+ *          name: closing
+ *          schema:
+ *            type: boolean
+ *         description: True if closing an open election; false if reopening a closed election
+ *     responses:
+ *       200:
+ *         description: Election state changed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 election:
+ *                   type: object
+ *                   $ref: '#/components/schemas/Election'
+ *       404:
+ *         description: Election not found 
+*/
+electionsRouter.post('/Election/:id/setOpenState', asyncHandler(setOpenState))
 
 /** 
  * @swagger

--- a/packages/frontend/src/hooks/useAPI.ts
+++ b/packages/frontend/src/hooks/useAPI.ts
@@ -96,6 +96,10 @@ export const useArchiveEleciton = (election_id: string) => {
     return useFetch<undefined, { election: Election }>(`/API/Election/${election_id}/archive`, 'post')
 }
 
+export const useSetOpenState = (election_id: string) => {
+    return useFetch<{ closing: boolean }, { election: Election }>(`/API/Election/${election_id}/setOpenState`, 'post')
+}
+
 export const useApproveRoll = (election_id: string) => {
     return useFetch<{ electionRollEntry: ElectionRoll }, object>(`/API/Election/${election_id}/rolls/approve`, 'post')
 }

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -1003,6 +1003,19 @@ admin_home:
     title: Confirm Archive {{capital_election}}
     message: Are you sure you wish to archive this {{election}}? This action cannot be undone.
 
+  close:
+    description: Close
+    subtext: Closes the {{election}}, preventing new votes
+    button: Close
+
+  open:
+    description: Open
+    subtext: Opens the {{election}}, allowing votes
+    button: Open
+
+  close_snack: 'Election successfully closed!'
+  open_snack: 'Election successfully opened!'
+
   share:
     description: Share {{capital_election}}
     # Button is defined in the top level share section


### PR DESCRIPTION
(Note: This is my first backend change and could probably use a second set of eyes, especially for the API additions.)

## Description
Allows election admins to close and open an election using a new button in the admin home page.
The button will not show up if the election has a start/end time set, to avoid issues with conflicting systems.

## Related Issues
Should close #812 