### PR TITLE
fix: warn when trying to vote in archived election

### DIFF
--- a/packages/frontend/src/components/Election/DraftWarning.tsx
+++ b/packages/frontend/src/components/Election/DraftWarning.tsx
@@ -1,19 +1,13 @@
-import { Box, Paper, Typography } from "@mui/material";
-import useElection from "../ElectionContextProvider";
+import ElectionStateWarning from "./ElectionStateWarning"
 
 const DraftWarning = () => {
-    const { t, election } = useElection();
-
-    if(election.state !== 'draft') return <></>
-
-    return <Paper sx={{display: 'flex', flexDirection: 'row', maxWidth: 600, gap: 2, padding: 2, m: 'auto', mb:4}}>
-        <Typography component="h3">⚠️</Typography>
-        <Box>
-            <Typography component="p"><b>{t('draft_warning.title')}</b></Typography>
-            <hr/>
-            <Typography component="p">{t('draft_warning.description')}</Typography>
-        </Box>
-    </Paper>
+    return (
+        <ElectionStateWarning
+            state="draft"
+            title="draft_warning.title"
+            description="draft_warning.description"
+        />
+    );
 }
 
 export default DraftWarning;

--- a/packages/frontend/src/components/Election/ElectionStateWarning.tsx
+++ b/packages/frontend/src/components/Election/ElectionStateWarning.tsx
@@ -1,0 +1,20 @@
+import { Box, Paper, Typography } from "@mui/material";
+import useElection from "../ElectionContextProvider";
+import type { ElectionState } from "@equal-vote/star-vote-shared/domain_model/Election"
+
+export default function ElectionStateWarning 
+        ({state, title, description}: {state: ElectionState, title: string, description: string}) {
+    
+    const { t, election } = useElection();
+    
+    if(election.state !== state) return <></>
+
+    return <Paper sx={{display: 'flex', flexDirection: 'row', maxWidth: 600, gap: 2, padding: 2, m: 'auto', mb:4}}>
+        <Typography component="h3">⚠️</Typography>
+        <Box>
+            <Typography component="p"><b>{t(title)}</b></Typography>
+            <hr/>
+            <Typography component="p">{t(description)}</Typography>
+        </Box>
+    </Paper>
+}

--- a/packages/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/packages/frontend/src/components/Election/Voting/VotePage.tsx
@@ -17,6 +17,7 @@ import { Race, VotingMethod } from "@equal-vote/star-vote-shared/domain_model/Ra
 import { useSubstitutedTranslation } from "~/components/util";
 import DraftWarning from "../DraftWarning";
 import SupportBlurb from "../SupportBlurb";
+import ElectionStateWarning from "../ElectionStateWarning"
 
 // I'm using the icon codes instead of an import because there was padding I couldn't get rid of
 // https://stackoverflow.com/questions/65721218/remove-material-ui-icon-margin
@@ -201,9 +202,15 @@ const VotePage = () => {
     return page.candidates.every(c => c.score === (allEqualIsAbstention(page) ? page.candidates[0].score : null));
   }
 
+  const isLastPage = (currentPage === pages.length-1)
+
   return (
     <Container disableGutters={true} maxWidth="sm">
       <DraftWarning/>
+      <ElectionStateWarning
+        state="archived"
+        title="archived_warning.title"
+        description="archived_warning.description"/>
       <BallotContext.Provider value={{
         instructionsRead: pages[currentPage].instructionsRead,
         setInstructionsRead: setInstructionsRead,
@@ -256,9 +263,11 @@ const VotePage = () => {
           </Stepper>
         }
         <PrimaryButton
-          onClick={() => (currentPage === pages.length-1)? setIsOpen(true) : setCurrentPageAndScroll(count => count + 1)}
-          sx={{ marginLeft: {xs: '10px', md: '40px'}}}>
-            {t((currentPage === pages.length-1)? 'ballot.submit_ballot' : 'ballot.next')}
+          onClick={() => isLastPage? setIsOpen(true) : setCurrentPageAndScroll(count => count + 1)}
+          sx={{ marginLeft: {xs: '10px', md: '40px'}}}
+          disabled={isLastPage && (election.state === "archived")}
+          >
+            {t(isLastPage? 'ballot.submit_ballot' : 'ballot.next')}
         </PrimaryButton>
       </Box>
       <SupportBlurb/>

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -825,6 +825,12 @@ draft_warning:
     All ballots will be counted as test votes and
     shall be reset prior to the final {{election}}.
 
+archived_warning:
+  title: Election is Archived
+  description: >
+    Unable to cast ballot: This {{election}} has been archived and is no longer accepting votes.
+    Please contact your Election Administrator if you need assistance.
+
 # Landing Page -> New Election Dialog
 election_creation:
   dialog_title: Create an Election or Poll


### PR DESCRIPTION
## Description

Addresses the bug noted [here](https://github.com/Equal-Vote/bettervoting/issues/891), that users aren't made aware that the election they are voting in is archived until they attempt to submit their vote.

Changes:
- The submit button is disabled when the election is archived
- A warning card is provided above the election when the election is archived (in the same style as the draft warning)
  - The `DraftWarning` component has been consolidated into a more modular component `ElectionStateWarning`, which `DraftWarning` is a concrete implementation of, along with the new "Election is archived" warning.

## Screenshots / Videos (frontend only) 

<img width="2537" height="1224" alt="image" src="https://github.com/user-attachments/assets/9a1a8ac7-a5b2-486a-8c5a-9d07964c56de" />
<img width="429" height="1102" alt="image" src="https://github.com/user-attachments/assets/164eab22-f4e4-475a-a652-f518b5129bba" />

## Related Issues

``fixes #891``