### PR TITLE
fix: scrub some potentially identifying information from an endpoint

### DIFF
--- a/packages/backend/src/Controllers/Ballot/getBallotsByElectionIDController.ts
+++ b/packages/backend/src/Controllers/Ballot/getBallotsByElectionIDController.ts
@@ -20,8 +20,20 @@ const getBallotsByElectionID = async (req: IElectionRequest, res: Response, next
         Logger.info(req, msg);
         throw new BadRequest(msg)
     }
+
+    // Scrub identifying information from ballots to preserve voter anonymity
+    const scrubbedBallots = ballots.map(ballot => ({
+        ...ballot,
+        history: undefined,
+        date_submitted: undefined,
+        create_date: undefined,
+        update_date: undefined,
+        user_id: undefined,
+        ip_hash: undefined
+    }));
+
     Logger.debug(req, "ballots = ", ballots);
-    res.json({ election: req.election, ballots: ballots })
+    res.json({ election: req.election, ballots: scrubbedBallots })
 }
 
 export {


### PR DESCRIPTION
## Description

The `/API/Election/[electionid]/ballots` endpoint currently reveals some information that could perhaps be used to let election admins figure out the ballot_id <-> voter_id link.  This scrubs the info before sending it out on the  endpoint.

I made some informal tests and it didn't immediately break things, but I wouldn't want to push this to main without some way of more clearly guaranteeing that I didn't break anything :)!  What is protocol for that?

## Related Issues

In service of #811 among other things.