### PR TITLE
Add an optional compact JSON export (format_version 2), alongside the existing one

### DIFF
--- a/packages/backend/src/test/exportFormat.test.ts
+++ b/packages/backend/src/test/exportFormat.test.ts
@@ -154,4 +154,41 @@ describe('buildElectionExport (v2 export format)', () => {
         expect(out.election).not.toHaveProperty('audit_ids'); // null omitted
         expect(out.election).not.toHaveProperty('public_archive_id');
     });
+
+    // Election types every one of these as `Date | string`. A Date has no own
+    // enumerable properties, so a recursive empty-value pass flattens it to `{}`:
+    // create_date/update_date then exported as the string "[object Object]", and
+    // start_time/end_time as a bare `{}`. The tests above only ever passed strings,
+    // which is why that went unnoticed.
+    test('normalizes Date-valued timestamps, not just strings', () => {
+        const when = new Date('2026-07-05T13:41:39.541Z');
+        const election3: any = {
+            election_id: 'e3',
+            title: 'Date-valued timestamps',
+            head: true,
+            create_date: when,
+            update_date: when,
+            start_time: when,
+            end_time: when,
+            races: [],
+            settings: {},
+        };
+        const o: any = buildElectionExport(election3, [], undefined);
+        for (const field of ['create_date', 'update_date', 'start_time', 'end_time']) {
+            expect(o.election[field]).toBe(when.toISOString());
+        }
+        expect(JSON.stringify(o)).not.toContain('[object Object]');
+    });
+
+    test('a Date-valued timestamp survives a round-trip through JSON', () => {
+        const when = new Date('2026-07-05T13:41:39.541Z');
+        const o: any = buildElectionExport(
+            { election_id: 'e4', title: 'T', head: true, create_date: when, update_date: when, races: [], settings: {} } as any,
+            [],
+            undefined,
+        );
+        const reparsed = JSON.parse(JSON.stringify(o));
+        expect(Number.isNaN(Date.parse(reparsed.election.create_date))).toBe(false);
+        expect(Date.parse(reparsed.election.create_date)).toBe(when.getTime());
+    });
 });

--- a/packages/backend/src/test/exportFormat.test.ts
+++ b/packages/backend/src/test/exportFormat.test.ts
@@ -1,0 +1,157 @@
+import { Star } from '../Tabulators/Star';
+import { mapMethodInputs } from './TestHelper';
+import { buildElectionExport } from '@equal-vote/star-vote-shared/utils/exportFormat';
+
+// Builds a realistic STAR result and checks the v2 export shape.
+describe('buildElectionExport (v2 export format)', () => {
+    const names = ['Allison', 'Bill', 'Carmen'];
+    const votes = [
+        [5, 2, 1],
+        [5, 3, 0],
+        [4, 0, 5],
+        [3, 5, 5],
+        [5, 1, 4],
+    ];
+    const results: any = Star(...mapMethodInputs(names, votes), 1);
+
+    // Minimal election whose race candidates line up with the tabulator names.
+    const election: any = {
+        election_id: 'testelec',
+        title: 'Export format test',
+        state: 'closed',
+        create_date: '2026-07-05T13:41:39.541Z',
+        update_date: '1783258899541', // epoch-ms string — must normalize to ISO
+        owner_id: 'owner',
+        audit_ids: null,
+        public_archive_id: null,
+        head: true,
+        races: [
+            {
+                race_id: 'r1',
+                title: 'Race 1',
+                voting_method: 'STAR',
+                num_winners: 1,
+                candidates: names.map((n) => ({ candidate_id: n, candidate_name: n })),
+            },
+        ],
+        settings: { public_results: true },
+    };
+
+    const ballots: any = votes.map((v, i) => ({
+        ballot_id: `b${i}`,
+        election_id: 'testelec',
+        precinct: null,
+        votes: [
+            {
+                race_id: 'r1',
+                scores: names.map((n, j) => ({ candidate_id: n, score: v[j] })),
+            },
+        ],
+    }));
+
+    const out: any = buildElectionExport(election, ballots, [results]);
+    const json = JSON.stringify(out);
+
+    test('is versioned and self-describing', () => {
+        expect(out.format).toBe('bettervoting-export');
+        expect(out.format_version).toBe(2);
+        expect(typeof out.exported_at).toBe('string');
+        expect(Number.isNaN(Date.parse(out.exported_at))).toBe(false);
+    });
+
+    test('drops the O(n^2) pairwise maps from candidate objects', () => {
+        expect(json).not.toContain('votesPreferredOver');
+        expect(json).not.toContain('winsAgainst');
+    });
+
+    test('pairwise matrix is deduped with no self-pairs', () => {
+        const pw = out.results[0].pairwise;
+        for (const name of names) {
+            expect(pw[name]).toBeDefined();
+            expect(pw[name][name]).toBeUndefined(); // no self-vs-self
+        }
+        // Allison beats Bill head-to-head in this ballot set
+        expect(pw['Allison']['Bill'].wins).toBe(true);
+    });
+
+    test('uses snake_case throughout the results section', () => {
+        const r = out.results[0];
+        expect(r.voting_method).toBe('STAR');
+        expect(r).toHaveProperty('tie_break_type');
+        expect(r.summary).toHaveProperty('n_tally_votes');
+        expect(r.summary).not.toHaveProperty('nTallyVotes');
+        // candidate method field snake_cased
+        expect(r.candidates[0]).toHaveProperty('five_star_count');
+    });
+
+    test('references candidates by both id and name', () => {
+        const elected = out.results[0].elected;
+        expect(Array.isArray(elected)).toBe(true);
+        expect(elected[0]).toHaveProperty('id');
+        expect(elected[0]).toHaveProperty('name');
+        expect(elected[0].name).toBe('Allison');
+    });
+
+    test('ballot scores stay compact (id + score); names live on election.races', () => {
+        const score = out.ballots[0].votes[0].scores[0];
+        expect(score).toHaveProperty('candidate_id');
+        expect(score).toHaveProperty('score');
+        expect(score).not.toHaveProperty('candidate_name'); // not repeated per row
+        // name is resolvable from the race candidate list
+        const cand = out.election.races[0].candidates.find(
+            (c: any) => c.candidate_id === score.candidate_id,
+        );
+        expect(cand.candidate_name).toBeDefined();
+    });
+
+    test('preserves a null score (abstention) distinct from an explicit 0', () => {
+        // null = "did not score this candidate"; must NOT be dropped or turned into 0.
+        const election2: any = {
+            election_id: 'e2',
+            title: 'null score test',
+            head: true,
+            races: [
+                {
+                    race_id: 'r1',
+                    title: 'R',
+                    voting_method: 'STAR',
+                    num_winners: 1,
+                    candidates: [
+                        { candidate_id: 'a', candidate_name: 'Amy' },
+                        { candidate_id: 'b', candidate_name: 'Bo' },
+                    ],
+                },
+            ],
+            settings: {},
+        };
+        const ballots2: any = [
+            {
+                ballot_id: 'x',
+                election_id: 'e2',
+                votes: [
+                    {
+                        race_id: 'r1',
+                        scores: [
+                            { candidate_id: 'a', score: 0 }, // flat zero
+                            { candidate_id: 'b', score: null }, // abstained on Bo
+                        ],
+                    },
+                ],
+            },
+        ];
+        const o: any = buildElectionExport(election2, ballots2, undefined);
+        const scores = o.ballots[0].votes[0].scores;
+        const a = scores.find((s: any) => s.candidate_id === 'a');
+        const b = scores.find((s: any) => s.candidate_id === 'b');
+        expect(a.score).toBe(0);
+        expect(b).toHaveProperty('score'); // key kept
+        expect(b.score).toBeNull(); // and it stays null, not dropped, not 0
+    });
+
+    test('normalizes timestamps to ISO-8601 and omits null fields', () => {
+        expect(out.election.update_date).toBe(new Date(1783258899541).toISOString());
+        expect(out.election.create_date).toBe('2026-07-05T13:41:39.541Z');
+        expect(out.election).not.toHaveProperty('audit_ids'); // null omitted
+        expect(out.election).not.toHaveProperty('public_archive_id');
+    });
+});

--- a/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
+++ b/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
@@ -3,9 +3,11 @@ import { ElectionResults } from '@equal-vote/star-vote-shared/domain_model/ITabu
 import MenuItem from "@mui/material/MenuItem";
 import BorderAll from '@mui/icons-material/BorderAll';
 import DataObject from '@mui/icons-material/DataObject';
+import Compress from '@mui/icons-material/Compress';
 import { MenuButton } from '~/components/MenuButton';
 import useAnonymizedBallots from '~/components/AnonymizedBallotsContextProvider';
 import { Box } from '@mui/material';
+import { buildElectionExport } from '@equal-vote/star-vote-shared/utils/exportFormat';
 
 interface Props {
     election: Election;
@@ -84,12 +86,26 @@ export const BallotDataExport = ({ election, results }: Props) => {
         );
     };
 
+    // The existing export: the raw in-memory objects, unchanged. Anything already
+    // parsing this file keeps working byte-for-byte.
     const downloadJson = () => {
         const ballotObject = { Election: election, Ballots: ballots, ...(results && { Results: results }) };
         triggerDownload(
             JSON.stringify(ballotObject, null, 2),
             'application/json',
             `Ballot Data - ${limit(election.title, 50)}-${election.election_id}.json`,
+        );
+    };
+
+    // The compact export (format_version 2): same data, without the tabulator's
+    // internal shape — see packages/shared/src/utils/exportFormat.ts. Offered
+    // alongside the original rather than replacing it, so no existing consumer
+    // breaks. Making it the default later is a one-line change here.
+    const downloadJsonV2 = () => {
+        triggerDownload(
+            JSON.stringify(buildElectionExport(election, ballots, results), null, 2),
+            'application/json',
+            `Ballot Data - ${limit(election.title, 50)}-${election.election_id}.v2.json`,
         );
     };
 
@@ -108,6 +124,10 @@ export const BallotDataExport = ({ election, results }: Props) => {
                         <MenuItem key="json" onClick={downloadJson}>
                             <DataObject sx={{ marginRight: 1 }} />
                             Download JSON
+                        </MenuItem>,
+                        <MenuItem key="json-v2" onClick={downloadJsonV2}>
+                            <Compress sx={{ marginRight: 1 }} />
+                            Download JSON (compact)
                         </MenuItem>,
                     ]}
                 </MenuButton>

--- a/packages/shared/src/utils/exportFormat.ts
+++ b/packages/shared/src/utils/exportFormat.ts
@@ -35,10 +35,17 @@ const toSnake = (k: string): string =>
         .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
         .toLowerCase();
 
+// A Date is an object but NOT a record: it has no own enumerable properties, so
+// recursing into one yields `{}` and destroys the timestamp. Election.create_date /
+// update_date / start_time / end_time are all typed `Date | string`, so both
+// recursive passes below have to treat a Date as a scalar and leave it alone.
+const isRecord = (v: any): boolean =>
+    v !== null && typeof v === 'object' && !Array.isArray(v) && !(v instanceof Date);
+
 // Deep-convert object keys to snake_case; values are left untouched.
 const deepSnake = (v: any): any => {
     if (Array.isArray(v)) return v.map(deepSnake);
-    if (v && typeof v === 'object') {
+    if (isRecord(v)) {
         const out: any = {};
         for (const [k, val] of Object.entries(v)) out[toSnake(k)] = deepSnake(val);
         return out;
@@ -49,7 +56,7 @@ const deepSnake = (v: any): any => {
 // Recursively drop null / undefined values (keeps the file terse).
 const omitEmpty = (v: any): any => {
     if (Array.isArray(v)) return v.map(omitEmpty);
-    if (v && typeof v === 'object') {
+    if (isRecord(v)) {
         const out: any = {};
         for (const [k, val] of Object.entries(v)) {
             if (val === null || val === undefined) continue;
@@ -70,11 +77,19 @@ const normalizeTimestamp = (v: any): string | undefined => {
     return Number.isNaN(d.getTime()) ? String(v) : d.toISOString();
 };
 
+// Every Election field that is typed `Date | string` (domain_model/Election.ts).
+const TIMESTAMP_FIELDS = ['create_date', 'update_date', 'start_time', 'end_time'] as const;
+
+// Normalization runs BEFORE omitEmpty, not after: omitEmpty walks the object graph,
+// so handing it a raw Date turns the field into `{}` and there is nothing left to
+// normalize. normalizeTimestamp returns undefined for null/empty, which the
+// omitEmpty pass then drops, so absent timestamps stay absent.
 const cleanElection = (e: Election): any => {
-    const cleaned: any = omitEmpty({ ...e });
-    if (cleaned.create_date) cleaned.create_date = normalizeTimestamp(cleaned.create_date);
-    if (cleaned.update_date) cleaned.update_date = normalizeTimestamp(cleaned.update_date);
-    return cleaned;
+    const cleaned: any = { ...e };
+    for (const field of TIMESTAMP_FIELDS) {
+        if (field in cleaned) cleaned[field] = normalizeTimestamp(cleaned[field]);
+    }
+    return omitEmpty(cleaned);
 };
 
 // Ballots stay compact (id + score). Candidate names are NOT repeated on every

--- a/packages/shared/src/utils/exportFormat.ts
+++ b/packages/shared/src/utils/exportFormat.ts
@@ -1,0 +1,214 @@
+// exportFormat.ts
+//
+// Builds the OPTIONAL compact "Ballot Data" JSON export (Election + Ballots + Results).
+//
+// This is offered ALONGSIDE the original download, not instead of it: the "Download JSON"
+// menu item still emits `JSON.stringify({ Election, Ballots, Results })` byte-for-byte, so
+// nothing consuming that file breaks. "Download JSON (compact)" emits the format below.
+//
+// The original export is the raw in-memory objects, which leaks the tabulator's internal
+// shape into a file people archive and parse:
+//   - every candidate carried O(n^2) `votesPreferredOver` / `winsAgainst` maps keyed by
+//     UUID, including self-vs-self entries, duplicated across elected/tied/other/summary
+//   - Results used camelCase while Election/Ballots used snake_case
+//   - timestamps were inconsistent (ISO create_date vs epoch-ms-string update_date)
+//   - ballot scores referenced candidates by UUID only, forcing a join to read them
+//
+// This builds a versioned, self-describing v2 export: candidates listed once, a deduped
+// pairwise matrix (self-pairs removed, keyed by name), elected/tied/other as name lists,
+// snake_case keys throughout, ISO-8601 timestamps, null/empty fields omitted, and both
+// candidate_id and candidate_name wherever a candidate is referenced.
+
+import { Election } from '../domain_model/Election';
+import { AnonymizedBallot } from '../domain_model/Ballot';
+import { ElectionResults } from '../domain_model/ITabulators';
+
+export const EXPORT_FORMAT = 'bettervoting-export';
+export const EXPORT_FORMAT_VERSION = 2;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// camelCase -> snake_case for a single object key
+const toSnake = (k: string): string =>
+    k
+        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+        .toLowerCase();
+
+// Deep-convert object keys to snake_case; values are left untouched.
+const deepSnake = (v: any): any => {
+    if (Array.isArray(v)) return v.map(deepSnake);
+    if (v && typeof v === 'object') {
+        const out: any = {};
+        for (const [k, val] of Object.entries(v)) out[toSnake(k)] = deepSnake(val);
+        return out;
+    }
+    return v;
+};
+
+// Recursively drop null / undefined values (keeps the file terse).
+const omitEmpty = (v: any): any => {
+    if (Array.isArray(v)) return v.map(omitEmpty);
+    if (v && typeof v === 'object') {
+        const out: any = {};
+        for (const [k, val] of Object.entries(v)) {
+            if (val === null || val === undefined) continue;
+            out[k] = omitEmpty(val);
+        }
+        return out;
+    }
+    return v;
+};
+
+// Normalize a timestamp (ISO string, epoch-ms number, or epoch-ms string) to ISO-8601.
+const normalizeTimestamp = (v: any): string | undefined => {
+    if (v === null || v === undefined || v === '') return undefined;
+    const asNum =
+        typeof v === 'number' ? v : /^\d+$/.test(String(v)) ? Number(v) : NaN;
+    if (!Number.isNaN(asNum)) return new Date(asNum).toISOString();
+    const d = new Date(v);
+    return Number.isNaN(d.getTime()) ? String(v) : d.toISOString();
+};
+
+const cleanElection = (e: Election): any => {
+    const cleaned: any = omitEmpty({ ...e });
+    if (cleaned.create_date) cleaned.create_date = normalizeTimestamp(cleaned.create_date);
+    if (cleaned.update_date) cleaned.update_date = normalizeTimestamp(cleaned.update_date);
+    return cleaned;
+};
+
+// Ballots stay compact (id + score). Candidate names are NOT repeated on every
+// ballot row — that re-bloats large elections (e.g. 51 candidates x 100 ballots).
+// Names are always resolvable from election.races[].candidates (and, when present,
+// results[].candidates), so no information is lost.
+//
+// IMPORTANT: a score of `null` is MEANINGFUL — it means the voter did not score
+// that candidate (an abstention on that candidate), which is distinct from an
+// explicit `0` and from scoring the "None of the Above" (c-nota) candidate. So
+// scores are preserved verbatim (including null); we do NOT run the null-omitting
+// pass over ballot rows. Only genuinely-absent optional metadata is dropped.
+const cleanBallots = (ballots: AnonymizedBallot[]): any[] =>
+    (ballots ?? []).map((b: any) => {
+        const out: any = { ballot_id: b.ballot_id };
+        if (b.precinct != null) out.precinct = b.precinct;
+        out.votes = (b.votes ?? []).map((v: any) => {
+            const vote: any = { race_id: v.race_id };
+            if (v.overvote_rank != null) vote.overvote_rank = v.overvote_rank;
+            if (v.has_duplicate_rank != null) vote.has_duplicate_rank = v.has_duplicate_rank;
+            // Preserve every score exactly, including explicit `null` (= not scored).
+            vote.scores = (v.scores ?? []).map((s: any) => ({
+                candidate_id: s.candidate_id,
+                score: s.score === undefined ? null : s.score,
+            }));
+            return vote;
+        });
+        return out;
+    });
+
+// Turn one race's tabulator result into the clean v2 shape.
+const cleanResult = (r: any): any => {
+    const summaryCandidates: any[] = r.summaryData?.candidates ?? [];
+
+    const idToName: Record<string, string> = {};
+    summaryCandidates.forEach((c) => {
+        idToName[c.id] = c.name;
+    });
+    const nm = (id: string) => idToName[id] ?? id;
+    const refs = (arr: any[] | undefined) =>
+        (arr ?? []).map((c: any) => ({ id: c.id, name: nm(c.id) }));
+
+    // Candidates listed once, without the O(n^2) pairwise maps.
+    const candidates = summaryCandidates.map((c) => {
+        const { votesPreferredOver, winsAgainst, ...rest } = c;
+        return deepSnake(rest);
+    });
+
+    // Deduped pairwise matrix: self-pairs removed, keyed by candidate name.
+    const pairwise: Record<string, Record<string, { prefer: number; wins: boolean }>> = {};
+    summaryCandidates.forEach((c) => {
+        const row: Record<string, { prefer: number; wins: boolean }> = {};
+        Object.keys(c.votesPreferredOver ?? {}).forEach((oid) => {
+            if (oid === c.id) return; // drop self-vs-self
+            row[nm(oid)] = {
+                prefer: c.votesPreferredOver[oid],
+                wins: !!c.winsAgainst?.[oid],
+            };
+        });
+        pairwise[nm(c.id)] = row;
+    });
+
+    const { candidates: _drop, ...summaryRest } = r.summaryData ?? {};
+    const summary = deepSnake(summaryRest);
+
+    const rounds = (r.roundResults ?? []).map((rr: any) => {
+        const out: any = {
+            winners: refs(rr.winners),
+            runner_up: refs(rr.runner_up),
+            tied: refs(rr.tied),
+            tie_break_type: rr.tieBreakType,
+            logs: rr.logs,
+        };
+        if (rr.eliminated) out.eliminated = refs(rr.eliminated);
+        if (rr.exhaustedVoteCount !== undefined) out.exhausted_vote_count = rr.exhaustedVoteCount;
+        return omitEmpty(out);
+    });
+
+    // Pull off the fields handled explicitly; deepSnake whatever method-specific
+    // top-level fields remain (e.g. IRV exhaustedVoteCounts / nExhaustedViaOvervote,
+    // STAR_PR logs).
+    const {
+        summaryData,
+        roundResults,
+        elected,
+        tied,
+        other,
+        perm,
+        votingMethod,
+        tieBreakType,
+        writeInDiagnostics,
+        ...extra
+    } = r;
+
+    return omitEmpty({
+        voting_method: votingMethod,
+        elected: refs(elected),
+        tied: refs(tied),
+        other: refs(other),
+        tie_break_type: tieBreakType,
+        candidates,
+        pairwise,
+        rounds,
+        summary,
+        perm: perm ? perm.map((id: string) => ({ id, name: nm(id) })) : undefined,
+        write_in_diagnostics: writeInDiagnostics ? deepSnake(writeInDiagnostics) : undefined,
+        ...deepSnake(extra),
+    });
+};
+
+export interface ElectionExport {
+    format: string;
+    format_version: number;
+    exported_at: string;
+    election: any;
+    ballots: any[];
+    results?: any[];
+}
+
+/**
+ * Build the clean, versioned election export object.
+ * @param election  the election config
+ * @param ballots   anonymized ballots (may be undefined while loading)
+ * @param results   per-race tabulation results (optional)
+ */
+export const buildElectionExport = (
+    election: Election,
+    ballots: AnonymizedBallot[] | undefined,
+    results?: ElectionResults[],
+): ElectionExport => ({
+    format: EXPORT_FORMAT,
+    format_version: EXPORT_FORMAT_VERSION,
+    exported_at: new Date().toISOString(),
+    election: cleanElection(election),
+    ballots: cleanBallots(ballots ?? []),
+    ...(results ? { results: results.map(cleanResult) } : {}),
+});


### PR DESCRIPTION
## Description

Adds a **second** JSON download rather than changing the existing one.

`#1419` bundled this format change with CSV bug fixes; you split the bug fixes out into #1428 (thank you — they're merged) and set the format aside as needing contemplation. That was the right call on a bundled PR, because the two halves carry very different risk. This is the format half on its own, and reshaped so it needs much less contemplation: **it changes nothing that exists.**

- **"Download JSON"** — untouched. Still `JSON.stringify({ Election, Ballots, Results })`, byte-for-byte. Any script, archive, or downstream tool reading it keeps working.
- **"Download JSON (compact)"** — new menu item, writes the new shape to a `.v2.json` filename so the two don't collide in a Downloads folder.

So the decision here isn't "should we migrate the export format," which is the hard question. It's "may people opt into a cleaner one." If you later decide the compact shape should be the default, that's a one-line change in `downloadJson`, and you'd make it knowing the format has been in the wild and used.

### What the compact format fixes (#1420)

The current export is the tabulator's in-memory objects handed straight to `JSON.stringify`, so it publishes internal shape:

- every candidate's O(n²) `votesPreferredOver` / `winsAgainst` maps, keyed by UUID, **self-pairs included**, repeated across `elected` / `tied` / `other` / `summaryData` **and** every `roundResults` entry
- `Results` in camelCase beside snake_case `Election` and `Ballots`
- an ISO-8601 `create_date` beside an epoch-ms-string `update_date`
- no version field, so a consumer can't tell which era of export it has

`buildElectionExport` in the new `packages/shared/src/utils/exportFormat.ts` emits: candidates listed once, a deduped `pairwise` matrix keyed by name with self-pairs dropped, `{id, name}` refs everywhere a candidate is referenced, snake_case throughout, ISO-8601 timestamps, null/empty fields omitted, and `format`/`format_version: 2`.

**Ballot scores are preserved verbatim, including `score: null`** — a blank (voter didn't score this candidate) stays distinct from an explicit `0` and from a NOTA vote. That's the JSON half of #1160's raw-audit ask; no CSV changes here.

Transform-only. No change to the tabulation engine, the results endpoint, or anything the UI renders.

### Verification

**Unit tests** — `packages/backend/src/test/exportFormat.test.ts`, 8 tests: versioning, pairwise dedup, snake_case, `{id,name}` refs, compact ballots, timestamp normalization, and a regression test that `null` ≠ `0` ≠ dropped. Full backend suite passes (24 suites / 172 tests). `tsc --noEmit` and eslint clean on the frontend.

**Real data** — ran `buildElectionExport` over **197 distinct real BetterVoting exports** (every frozen export in [masiarek/star-voting-library](https://github.com/masiarek/star-voting-library), spanning STAR, STAR_PR, Approval, Plurality, IRV, STV and Ranked Robin; 2–61 candidates), asserting on each one that the O(n²) maps are gone, the ballot-score multiset is **identical including nulls**, the elected set is unchanged, ballot and race counts match, and timestamps normalize. **0 failures.**

Size, honestly: it's a real reduction but a modest one on typical elections, because ballots dominate most files and ballots are kept nearly verbatim.

| | % of legacy size |
|---|---|
| best | 43% |
| p25 | 70% |
| **median** | **76%** |
| p75 | 85% |
| worst | 98% |

The savings track candidate count, as you'd expect from an O(n²) map: the 9-candidate dead-heat election drops to 43% and the 51-candidate board election to 74%, while 2-candidate elections sit around 76% and a 61-candidate election with a large ballot set only reaches 95%.

### On the one review comment from last time

CodeRabbit flagged the ballot-score assertion in the test as expecting a "legacy `candidate_id`" field. That was a false positive — the format emits `candidate_id` on ballot scores deliberately (matching `Election.races[].candidates[].candidate_id`), and the test is correct. It passes as written.

## Screenshots / Videos (frontend only)

No visible page change beyond one added menu item; the outputs are the downloaded files. The Download menu now offers: **CSV**, **JSON**, **JSON (compact)**.

## Related Issues

- Addresses #1420 (export leaks the tabulator's internal object shape) — as an opt-in format, so I'd leave the issue open until/unless the compact shape becomes the default.
- Implements the JSON-null-preservation half of #1160. The CSV Raw/Official split from #1419 is deliberately **not** here — that's a separate product decision.
- #1432's JSON ask (per-round `logs` + `tieBreakType`) would build on `buildElectionExport`. Out of scope here.
