### PR TITLE
docs: add a Tips and Tricks page

### DIFF
--- a/docs/help/tips_and_tricks.md
+++ b/docs/help/tips_and_tricks.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: Tips and Tricks
+nav_order: 9
+parent: BetterVoting Documentation
+---
+
+{:toc}
+
+# Tips and Tricks
+
+Small things that make an election easier to read, easier to trust, and easier to share. None of these are required — they're the details that are easy to miss on your first election.
+
+## Put links in your description, not just a URL
+
+The **election description** and each **race description** are formatted, so you can add a real, clickable link:
+
+```
+Read the full proposal at [our website](https://example.org/proposal).
+```
+
+A bare URL is **not** turned into a link. If you write this:
+
+```
+Read the full proposal at https://example.org/proposal
+```
+
+voters see the address as plain text and have to select and copy it by hand. On a phone that is a real obstacle, and it is the single most common way a description ends up less useful than it should be.
+
+The same formatting also gives you:
+
+| What you type | What voters see |
+|---|---|
+| `[click here](https://example.org)` | a link, opening in a new tab |
+| `**important**` | **important** |
+| a blank line between two paragraphs | two paragraphs |
+
+Links open in a new tab, so clicking one never takes a voter away from a ballot they're partway through filling in.
+
+## Know where each description actually appears
+
+The two description fields show up in different places, which is worth knowing before you decide what to write where:
+
+| Field | Where voters see it |
+|---|---|
+| **Election description** | the election's home page, the card on **Browse Polls**, and email invitations |
+| **Race description** | on the ballot, under that race's title |
+
+{: .note }
+> Neither description appears on the **results** page. If you want people reading the results to find your background material — a proposal, a rules document, an explanation of how the count works — link to it from somewhere that survives the election, and share that link alongside the results link.
+
+## Titles are plain text
+
+Election titles and race titles are shown exactly as typed. Formatting and links don't work there, so `[my org](https://example.org)` in a title will display as those literal characters, brackets and all. Keep titles short and descriptive, and put anything else in the description.
+
+## Give candidates their own link
+
+Candidates have a dedicated **link** field — you don't need to put candidate URLs in the description. When it's set, the candidate's name on the ballot becomes a link to that page, with a small "opens in a new tab" icon beside it. It's the tidiest way to let voters research a choice without leaving the ballot, and it keeps your description short.
+
+There's a separate field for a party affiliation link, which behaves the same way.
+
+## Say what happens in a tie, before you start
+
+Ties are rare in STAR Voting, but they're much easier to handle if the rule was agreed in advance rather than argued afterwards. See [Ties](ties.html) for the protocol BetterVoting uses and the reasoning behind it.
+
+## Test with a draft first
+
+Send yourself the ballot link and vote on it before you invite anyone. It takes a minute and it catches the things that are awkward to fix later: a candidate name that's ambiguous on a small screen, a race description that's too long to read on a phone, a link that points at the wrong page.
+
+---
+
+*Something here out of date, or a tip you think belongs on this page? Corrections are welcome — see the [contribution guide](../contributions/0_contribution_guide.html).*


### PR DESCRIPTION
Adds `docs/help/tips_and_tricks.md` — a short page of things election organisers routinely miss. It's all existing behaviour; nothing here asks for a code change.

The tip that prompted it: election and race descriptions go through `formatMarkdown()`, so `[text](url)` becomes a real link — but a bare URL doesn't. Outside `ElectionDetailsForm`, nothing in the product says so, so descriptions ending in a pasted address are common, and voters end up selecting and copying the address by hand. On a phone that's a genuine obstacle.

The other four:

- **Where each description actually appears** — election description on the election home page, the Browse Polls card, and email invitations; race description on the ballot. Neither appears on the results page, which is worth knowing if you want people reading results to find your background material.
- **Titles are plain text.** `election.title` and `race.title` render straight through `<Typography>`, so markdown in a title displays literally.
- **Candidates have a dedicated link field.** `candidate_url` turns the name on the ballot into a link with an "opens in a new tab" icon — tidier than putting candidate URLs in the description, and not widely known.
- Agree the tie rule in advance (links to the existing Ties page); test with a draft ballot first.

Every factual claim is read off `main` as of this branch rather than from memory. One tip — whether a description can still be edited once voting is open — was cut because I couldn't establish it from the code; happy to add it back if someone can confirm the rule.

Style follows the existing `docs/help/` pages: just-the-docs front matter, `parent: BetterVoting Documentation`, `nav_order: 9` (after Preliminary Results, before the `99`s). Internal links are relative `.html`, matching how the frontend already links to `docs.bettervoting.com/help/preliminary_results.html`.

Happy to cut, reword, or split any of it — and if the page is better placed somewhere other than under Help, say the word.

### Related

The discoverability gap is arguably a product issue rather than a docs one, so I've filed it separately as #1497. Short version: `a8efc073` shipped the markdown feature with a `Supports **bold** and [link text](url) formatting` helper under both Description fields; the RaceForm rewrite dropped that helper (authored before the markdown feature, landed after it, so the rebase removed a hint its author had never seen), and the new wizard's Description field never had one. The helper now survives only in `ElectionDetailsForm` and `SendEmailDialog`. This page helps, but restoring the in-product hint would help more.
