### PR TITLE
Select elections in the table and archive them in one go

### DIFF
--- a/packages/frontend/src/components/Elections/ElectionsYouManage.tsx
+++ b/packages/frontend/src/components/Elections/ElectionsYouManage.tsx
@@ -1,18 +1,23 @@
 import { useEffect, useMemo } from 'react'
 import { Election } from "@equal-vote/star-vote-shared/domain_model/Election"
 import useAuthSession from '../AuthSessionContextProvider';
-import { useClaimElection, useGetElections } from '../../hooks/useAPI';
+import { archiveElections, BulkArchiveTarget, useClaimElection, useGetElections } from '../../hooks/useAPI';
 import { useNavigate } from 'react-router';
-import EnhancedTable from '../EnhancedTable';
+import EnhancedTable, { BulkAction } from '../EnhancedTable';
 import { PrimaryButton } from '../styles';
 import useSnackbar from '../SnackbarContext';
+import useConfirm from '../ConfirmationDialogProvider';
+import { useSubstitutedTranslation } from '../util';
 import { useSessionStorage } from '~/hooks/useSessionStorage';
 import { useCookie } from '~/hooks/useCookie';
+import ArchiveIcon from '@mui/icons-material/Archive';
 
 const ElectionsYouManage = () => {
     const navigate = useNavigate();
     const authSession = useAuthSession()
     const { setSnack } = useSnackbar()
+    const confirm = useConfirm()
+    const { t } = useSubstitutedTranslation()
 
     const { data, isPending, makeRequest: fetchElections } = useGetElections()
 
@@ -74,6 +79,61 @@ const ElectionsYouManage = () => {
         }
     }, [data]);
             
+    // Only the owner can change an election's state (permissions.canEditElectionState),
+    // and this table also lists elections where you're merely an admin or auditor —
+    // so anything you don't own is reported as skipped rather than sent and 401'd.
+    const bulkArchive = async (rows: {raw: Election}[]) => {
+        const targets: BulkArchiveTarget[] = rows
+            .filter(row => row.raw.owner_id === id && row.raw.state !== 'archived')
+            .map(row => ({
+                election_id: String(row.raw.election_id),
+                title: row.raw.title,
+                update_date: String(row.raw.update_date),
+            }))
+        const ineligible = rows.length - targets.length
+
+        if (targets.length === 0) {
+            setSnack({
+                message: t('bulk_actions.archive.none_eligible'),
+                severity: 'warning',
+                open: true,
+                autoHideDuration: 6000,
+            })
+            return
+        }
+
+        const confirmed = await confirm({
+            title: t('bulk_actions.archive.confirm_title'),
+            message: t('bulk_actions.archive.confirm_message', { count: targets.length, ineligible }),
+            submit: t('bulk_actions.archive.confirm_submit', { count: targets.length }),
+        })
+        if (!confirmed) return
+
+        const outcome = await archiveElections(targets)
+        const parts = [t('bulk_actions.archive.done', { count: outcome.archived.length })]
+        if (ineligible > 0) parts.push(t('bulk_actions.archive.skipped', { count: ineligible }))
+        if (outcome.failed.length > 0) parts.push(t('bulk_actions.archive.failed', {
+            count: outcome.failed.length,
+            first_title: outcome.failed[0].target.title,
+            first_error: outcome.failed[0].message,
+        }))
+
+        setSnack({
+            message: parts.join(' '),
+            severity: outcome.failed.length > 0 ? 'warning' : 'success',
+            open: true,
+            autoHideDuration: outcome.failed.length > 0 ? null : 6000,
+        })
+        fetchElections()
+    }
+
+    const bulkActions: BulkAction[] = [{
+        key: 'archive',
+        label: t('bulk_actions.archive.menu_item'),
+        icon: <ArchiveIcon fontSize='small'/>,
+        onAction: bulkArchive,
+    }]
+
     return <EnhancedTable
         title='My Elections & Polls'
         headKeys={['title', 'update_date', 'election_state', 'start_time', 'end_time', 'description']}
@@ -83,6 +143,8 @@ const ElectionsYouManage = () => {
         handleOnClick={(row) => navigate(`/${String(row.raw.election_id)}`)}
         defaultSortBy='update_date'
         emptyContent={<>You don&apos;t have any elections yet<br/><PrimaryButton onClick={() => navigate('/new_election')}>Create Election</PrimaryButton></>}
+        bulkActions={bulkActions}
+        getRowId={(row) => String(row.raw.election_id)}
     />
 }
 

--- a/packages/frontend/src/components/EnhancedTable.tsx
+++ b/packages/frontend/src/components/EnhancedTable.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useState, useMemo, ReactNode, MouseEvent, ChangeEvent } from 'react';
+import { useState, useMemo, useEffect, ReactNode, MouseEvent, ChangeEvent } from 'react';
 import { alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
@@ -18,7 +18,9 @@ import Paper from '@mui/material/Paper';
 import { makeChipStyle } from './ElectionForm/Details/ElectionStateChip';
 import { visuallyHidden } from '@mui/utils';
 import { epochToDateString, getLocalTimeZoneShort, NumberObject, useSubstitutedTranslation } from './util';
-import { Checkbox, FormControl, ListItemText, MenuItem, Select, TextField, Chip } from '@mui/material';
+import { Button, Checkbox, FormControl, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Select, TextField, Chip, Tooltip } from '@mui/material';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import CloseIcon from '@mui/icons-material/Close';
 import { ElectionState } from '@equal-vote/star-vote-shared/domain_model/Election';
 import Link from "@mui/material/Link";
 import { describeHistoryEvent, formatHistoryTimestamp, historyChipLabel, historyFilterGroups } from './Election/electionHistoryFormat';
@@ -31,9 +33,22 @@ interface TableData {
   [key: string]: string | number
 }
 
+// An entry in the toolbar's Actions menu, shown once rows are selected.
+// onAction receives the selected rows (the formatted rows, so the underlying
+// record is on row.raw) and may be async — the menu stays disabled until it settles.
+export interface BulkAction {
+  key: string;
+  label: string;
+  icon?: ReactNode;
+  onAction: (rows: any[]) => void | Promise<void>;
+}
+
 interface EnhancedTableToolbarProps {
   numSelected: number;
   tableTitle: string;
+  actions?: { key: string, label: string, icon?: ReactNode, run: () => void }[];
+  onClearSelection?: () => void;
+  actionsPending?: boolean;
 }
 
 interface HeadCell {
@@ -56,6 +71,10 @@ interface EnhancedTableHeadProps {
   headCells: HeadCell[];
   filters: string[];
   setFilters: (filtersUpdater: (filters: string[]) => string[]) => void
+  selectable?: boolean;
+  allOnPageSelected?: boolean;
+  someOnPageSelected?: boolean;
+  onSelectAllOnPage?: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
 const headCellPool = {
@@ -306,6 +325,12 @@ interface EnhancedTableProps {
   isPending: boolean
   pendingMessage: string,
   emptyContent: any,
+  // Row selection is opt-in: a table only grows checkboxes when it passes both
+  // bulkActions and getRowId. Without that the other tables sharing this component
+  // (public archive, elections you voted in, ...) would sprout checkboxes with
+  // nothing to do.
+  bulkActions?: BulkAction[],
+  getRowId?: (row: any) => string,
 }
 
 const limit = (string = '', limit = 0) => {
@@ -427,6 +452,17 @@ function EnhancedTableHead(props: EnhancedTableHeadProps) {
   return (
     <TableHead>
       <TableRow>
+        {props.selectable &&
+          <TableCell padding="checkbox" sx={{ verticalAlign: 'top', pt: 2 }}>
+            <Checkbox
+              color="primary"
+              indeterminate={props.someOnPageSelected && !props.allOnPageSelected}
+              checked={props.allOnPageSelected}
+              onChange={props.onSelectAllOnPage}
+              slotProps={{ input: { 'aria-label': 'select all rows on this page' } }}
+            />
+          </TableCell>
+        }
         {props.headCells.map((headCell, cellInd) => (
           <TableCell
             key={headCell.id}
@@ -487,6 +523,9 @@ function EnhancedTableHead(props: EnhancedTableHeadProps) {
 
 function EnhancedTableToolbar(props: EnhancedTableToolbarProps) {
   const { numSelected } = props;
+  const { t } = useSubstitutedTranslation();
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const hasActions = numSelected > 0 && (props.actions?.length ?? 0) > 0;
 
   return (
     <Toolbar
@@ -500,14 +539,66 @@ function EnhancedTableToolbar(props: EnhancedTableToolbarProps) {
       }}
     >
 
-      <Typography
-        sx={{ flex: '1 1 100%' }}
-        variant="h6"
-        id="tableTitle"
-        component="div"
-      >
-        {props.tableTitle}
-      </Typography>
+      {hasActions ?
+        <>
+          <Typography
+            sx={{ flex: '1 1 100%' }}
+            color="inherit"
+            variant="subtitle1"
+            component="div"
+          >
+            {t('bulk_actions.selected', { count: numSelected })}
+          </Typography>
+          <Button
+            variant="outlined"
+            size="small"
+            sx={{ whiteSpace: 'nowrap' }}
+            disabled={props.actionsPending}
+            endIcon={<ArrowDropDownIcon />}
+            aria-haspopup="menu"
+            onClick={(e) => setMenuAnchor(e.currentTarget)}
+          >
+            {t('bulk_actions.menu_button')}
+          </Button>
+          <Menu
+            anchorEl={menuAnchor}
+            open={Boolean(menuAnchor)}
+            onClose={() => setMenuAnchor(null)}
+          >
+            {props.actions.map(action =>
+              <MenuItem
+                key={action.key}
+                onClick={() => { setMenuAnchor(null); action.run(); }}
+              >
+                {action.icon && <ListItemIcon>{action.icon}</ListItemIcon>}
+                <ListItemText>{action.label}</ListItemText>
+              </MenuItem>
+            )}
+          </Menu>
+          <Tooltip title={t('bulk_actions.clear')}>
+            <span>
+              <IconButton
+                size="small"
+                sx={{ ml: 1 }}
+                disabled={props.actionsPending}
+                aria-label={t('bulk_actions.clear')}
+                onClick={props.onClearSelection}
+              >
+                <CloseIcon />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </>
+        :
+        <Typography
+          sx={{ flex: '1 1 100%' }}
+          variant="h6"
+          id="tableTitle"
+          component="div"
+        >
+          {props.tableTitle}
+        </Typography>
+      }
     </Toolbar>
   );
 }
@@ -517,7 +608,8 @@ function EnhancedTableToolbar(props: EnhancedTableToolbarProps) {
 export default function EnhancedTable(props: EnhancedTableProps) {
   const [order, setOrder] = useState<Order>(props.defaultSortBy == 'email' ? 'asc' : 'desc');
   const [orderBy, setOrderBy] = useState<Extract<keyof TableData, string>>(props.defaultSortBy);
-  const [selected] = useState<readonly string[]>([]);
+  const [selected, setSelected] = useState<readonly string[]>([]);
+  const [actionsPending, setActionsPending] = useState(false);
   const [page, setPage] = useState(0);
   const [dense] = useState(true);
   const [rowsPerPage, setRowsPerPage] = useState(25);
@@ -596,13 +688,70 @@ export default function EnhancedTable(props: EnhancedTableProps) {
     [order, orderBy, page, rowsPerPage, filteredRows],
   );
 
+  const selectable = Boolean(props.bulkActions?.length && props.getRowId);
+  const getRowId = props.getRowId ?? (() => '');
+  const columnCount = headCells.length + (selectable ? 1 : 0);
+
+  // A selected row that a filter has since hidden must not stay actionable — otherwise
+  // "Archive 12" could reach rows the user can no longer see.
+  useEffect(() => {
+    if (!selectable) return;
+    const stillPresent = new Set(filteredRows.map(row => getRowId(row)));
+    setSelected(prev => {
+      const next = prev.filter(id => stillPresent.has(id));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [filteredRows, selectable]);
+
+  const selectedRows = useMemo(
+    () => selectable ? filteredRows.filter(row => selected.includes(getRowId(row))) : [],
+    [filteredRows, selected, selectable],
+  );
+
+  // "Select all" is scoped to the current page — the rows actually on screen.
+  const visibleIds = useMemo(() => visibleRows.map(row => getRowId(row)), [visibleRows, selectable]);
+  const numSelectedOnPage = visibleIds.filter(id => selected.includes(id)).length;
+
+  const handleSelectAllOnPage = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.checked) {
+      setSelected(prev => Array.from(new Set([...prev, ...visibleIds])));
+    } else {
+      setSelected(prev => prev.filter(id => !visibleIds.includes(id)));
+    }
+  };
+
+  const handleToggleRow = (id: string) => {
+    setSelected(prev => prev.includes(id) ? prev.filter(other => other !== id) : [...prev, id]);
+  };
+
+  const toolbarActions = (props.bulkActions ?? []).map(action => ({
+    key: action.key,
+    label: action.label,
+    icon: action.icon,
+    run: async () => {
+      setActionsPending(true);
+      try {
+        await action.onAction(selectedRows);
+      } finally {
+        setActionsPending(false);
+        setSelected([]);
+      }
+    },
+  }));
+
 
   return (
     <Container>
       <Box sx={{ pt: 2, width: '100%', display: "flex", justifyContent: "center", alignItems: "center", flexDirection: "column" }}>
         {props.isPending && <Typography align='center' variant="h3" component="h2"> {props.pendingMessage} </Typography>}
         {!props.isPending && <Paper elevation={8} sx={{ width: '100%', mb: 2 }}>
-          <EnhancedTableToolbar numSelected={selected.length} tableTitle={props.title} />
+          <EnhancedTableToolbar
+            numSelected={selectedRows.length}
+            tableTitle={props.title}
+            actions={toolbarActions}
+            actionsPending={actionsPending}
+            onClearSelection={() => setSelected([])}
+          />
           <TableContainer>
             <Table
               sx={{ minWidth: 750 }}
@@ -616,11 +765,15 @@ export default function EnhancedTable(props: EnhancedTableProps) {
                 headCells={headCells}
                 filters={filters}
                 setFilters={setFilters}
+                selectable={selectable}
+                allOnPageSelected={visibleIds.length > 0 && numSelectedOnPage === visibleIds.length}
+                someOnPageSelected={numSelectedOnPage > 0}
+                onSelectAllOnPage={handleSelectAllOnPage}
               />
               <TableBody>
                 {visibleRows.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={headCells.length} align="center" sx={{ py: 4 }}>
+                    <TableCell colSpan={columnCount} align="center" sx={{ py: 4 }}>
                       <Typography variant="body1" color="text.secondary">
                         {props.emptyContent}
                       </Typography>
@@ -629,14 +782,29 @@ export default function EnhancedTable(props: EnhancedTableProps) {
                 )}
                 {visibleRows.map((row, index) => {
                   const labelId = `enhanced-table-checkbox-${index}`;
+                  const rowId = getRowId(row);
+                  const isSelected = selectable && selected.includes(rowId);
                   return (
                     <TableRow
                       hover
                       onClick={() => props.handleOnClick(row)}
                       tabIndex={-1}
                       key={labelId}
+                      selected={isSelected}
                       sx={{ cursor: 'pointer' }}
                     >
+                      {selectable &&
+                        // The whole row is a link to the election, so the checkbox has to
+                        // swallow the click or ticking a box navigates away from the list.
+                        <TableCell padding="checkbox" onClick={(e) => e.stopPropagation()}>
+                          <Checkbox
+                            color="primary"
+                            checked={isSelected}
+                            onChange={() => handleToggleRow(rowId)}
+                            slotProps={{ input: { 'aria-labelledby': labelId } }}
+                          />
+                        </TableCell>
+                      }
                       {headCells.map((col, colInd) => {
                         //const isElectionState = col.id === 'election_state';
                         const groupFilter = col.filterType == 'groups';
@@ -667,7 +835,7 @@ export default function EnhancedTable(props: EnhancedTableProps) {
                       height: (dense ? 33 : 53) * emptyRows,
                     }}
                   >
-                    <TableCell colSpan={6} />
+                    <TableCell colSpan={columnCount} />
                   </TableRow>
                 )}
               </TableBody>

--- a/packages/frontend/src/hooks/useAPI.ts
+++ b/packages/frontend/src/hooks/useAPI.ts
@@ -143,6 +143,62 @@ export const useArchiveEleciton = (election_id: string) => {
     return useFetch<{ expected_update_date: string }, { election: Election }>(`/API/Election/${election_id}/archive`, 'post')
 }
 
+// Bulk archive is a plain function rather than a useFetch hook: useFetch binds one
+// election_id at render time, and hooks can't be called in a loop over a selection.
+// The per-election endpoint is reused as-is so that each archive keeps the auth,
+// optimistic-concurrency and history-logging that router.param('id', ...) provides.
+export interface BulkArchiveTarget {
+    election_id: string
+    title: string
+    update_date: string
+}
+
+export interface BulkArchiveOutcome {
+    archived: BulkArchiveTarget[]
+    failed: { target: BulkArchiveTarget, message: string }[]
+}
+
+const archiveOneElection = async (target: BulkArchiveTarget): Promise<void> => {
+    const res = await fetch(`/API/Election/${target.election_id}/archive`, {
+        method: 'post',
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ expected_update_date: target.update_date }),
+    })
+    if (res.ok) return
+    let message = `${res.status}`
+    try {
+        const body = await res.json()
+        if (body?.error) message = body.error
+    } catch { /* non-JSON error body, keep the status */ }
+    throw new Error(message)
+}
+
+// Archives in small batches so a 40-election selection doesn't open 40 sockets at once.
+// Partial success is expected and reported rather than rolled back — re-running a bulk
+// archive is harmless, since the backend rejects an already-archived election.
+export const archiveElections = async (
+    targets: BulkArchiveTarget[],
+    batchSize = 5,
+): Promise<BulkArchiveOutcome> => {
+    const outcome: BulkArchiveOutcome = { archived: [], failed: [] }
+    for (let i = 0; i < targets.length; i += batchSize) {
+        const batch = targets.slice(i, i + batchSize)
+        const results = await Promise.all(batch.map(target =>
+            archiveOneElection(target)
+                .then(() => ({ target, message: null }))
+                .catch((err: Error) => ({ target, message: err.message || 'Unknown error' }))
+        ))
+        results.forEach(({ target, message }) => {
+            if (message === null) outcome.archived.push(target)
+            else outcome.failed.push({ target, message })
+        })
+    }
+    return outcome
+}
+
 export const useSetOpenState = (election_id: string) => {
     return useFetch<{ open: boolean, expected_update_date: string }, { election: Election }>(`/API/Election/${election_id}/setOpenState`, 'post')
 }

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -1072,6 +1072,27 @@ election_state:
   closed: closed
   archived: archived
 
+# Bulk actions in a table toolbar (My Elections & Polls)
+bulk_actions:
+  selected_one: '{{count}} selected'
+  selected_other: '{{count}} selected'
+  menu_button: Actions
+  clear: Clear selection
+  archive:
+    menu_item: Archive
+    confirm_title: Confirm Archive
+    confirm_message_one: Archive this election? Archiving prevents future changes and hides it from this page. This action cannot be undone.
+    confirm_message_other: Archive these {{count}} elections? Archiving prevents future changes and hides them from this page. This action cannot be undone.
+    confirm_submit_one: Archive 1 election
+    confirm_submit_other: Archive {{count}} elections
+    done_one: Archived 1 election.
+    done_other: Archived {{count}} elections.
+    skipped_one: Skipped 1 that you don't own or that was already archived.
+    skipped_other: Skipped {{count}} that you don't own or that were already archived.
+    failed_one: '1 failed — {{first_title}}: {{first_error}}'
+    failed_other: '{{count}} failed, starting with {{first_title}}: {{first_error}}'
+    none_eligible: Nothing to archive here — you can only archive elections you own that aren't already archived.
+
 # Admin Home
 admin_home:
   header_invitations_sent: Invitations have been sent to your voters


### PR DESCRIPTION
## Description

`/manage` lists every election you officiate, and the only way to tidy it up today is to open each one and archive it from its admin page. After a lot of testing that adds up. This adds row selection to the table plus an **Actions** menu in the toolbar, so you can archive a batch in one pass.

**Why an Actions menu and not right-click** (which #820 asks for): right-click has no touch story and is unusual on the web, and the ElectionBuddy example quoted in the issue isn't right-click either — it's "select the checkboxes, then choose Delete from the Actions menu". The MUI table this is built on already ships that pattern, so it came nearly free.

**This is the archive half only.** Notes on delete at the bottom.

### What's in it

`EnhancedTable` was already carrying the skeleton of MUI's own EnhancedTable demo with the selection parts removed — a `selected` state destructured without its setter, a toolbar that still takes `numSelected` and still has the highlight styling for it, row ids still named `enhanced-table-checkbox-N`. Most of this reconnects what was there:

- **Selection is opt-in** via new `bulkActions` + `getRowId` props. The other tables sharing this component (Open Elections, Public Archive, Elections You Voted In, Invitations, Query Tool, Voter Rolls, Election History, Upload Elections) render exactly as before.
- **The header checkbox selects the current page** — "what we see on screen", per the issue. That's `visibleRows`, which the component already computes.
- **The checkbox cell stops click propagation.** The whole `<TableRow>` is a link to the election, so without this, ticking a box navigates away from the list.
- **A selected row that a filter later hides is dropped from the selection**, so a bulk action can never reach a row the user can no longer see.

### No backend change

The client loops over the existing `POST /Election/:id/archive` in batches of 5. That endpoint's permission check, its `expected_update_date` optimistic-concurrency guard and its history entry all hang off `electionsRouter.param('id', ...)`, so a new bulk endpoint taking an array of ids would get none of them and would have to reimplement all three. Reusing the per-election route keeps each archive a normal, fully-audited write — the DB shows each one getting a new `head` version with `state='archived'` and its predecessor demoted, exactly as a single archive does.

The trade-off is that a bulk run isn't atomic. Partial results are reported rather than rolled back, and re-running is harmless because the backend rejects an already-archived election.

Two smaller behaviours worth flagging for review:

- **Rows you don't own are filtered out client-side rather than sent and 401'd.** `canEditElectionState` is `[system_admin, owner]`, but this table also lists elections where you're only an admin, auditor or credentialer. Those are reported as skipped.
- **Archiving is one-way.** Nothing moves an election out of `archived` (`setOpenState` refuses any state that isn't `open`/`closed`), so the confirm dialog names the count and says the action can't be undone. If an unarchive ever lands, a bulk archive becomes considerably less scary — happy to follow up with one if that's wanted.

All new strings are in `en.yaml` under `bulk_actions`, with `_one`/`_other` plurals.

**One open question for reviewers.** The toolbar is contextual — the Actions button only appears once a row is ticked, which is what MUI's own demo does and what Gmail-style tables do. The first person to try this build looked at the resting page and said "missing actions", then found it a moment later by ticking a box. So there's a real discoverability cost. The alternative is to always render the button and disable it until something is selected. It's a two-line change; say the word and I'll switch it.

## Screenshots / Videos (frontend only)

### Desktop

Three selected — the toolbar swaps the title for the count, the Actions button and a clear-selection ✕, and the header checkbox goes indeterminate:

![Three elections selected](https://raw.githubusercontent.com/masiarek/star-server/pr820-screenshots/desktop-1-selected.png)

The Actions menu:

![Actions menu open](https://raw.githubusercontent.com/masiarek/star-server/pr820-screenshots/desktop-2-actions-menu.png)

Confirmation, naming the count:

![Confirm dialog](https://raw.githubusercontent.com/masiarek/star-server/pr820-screenshots/desktop-3-confirm.png)

After — the three are gone from the default view (the State filter already defaults to `archived: false`), selection cleared, one summary snackbar:

![After archiving](https://raw.githubusercontent.com/masiarek/star-server/pr820-screenshots/desktop-4-after.png)

### Mobile (320px)

The toolbar fits without overflowing (measured: 288px content in a 288px box, no horizontal page scroll):

<img src="https://raw.githubusercontent.com/masiarek/star-server/pr820-screenshots/mobile-1-selected-320.png" width="320">
<img src="https://raw.githubusercontent.com/masiarek/star-server/pr820-screenshots/mobile-2-actions-menu-320.png" width="320">
<img src="https://raw.githubusercontent.com/masiarek/star-server/pr820-screenshots/mobile-3-confirm-320.png" width="320">

### How it was tested

Local stack (postgres + keycloak + both dev servers), 11 seeded elections, driven by Playwright:

- archived 3 → list went 11 → 8, snackbar "Archived 3 elections."
- DB confirms each archived election got a new `head` row with `state='archived'`, predecessor demoted to `head=false`
- select-all-on-page ticked 8/8; the clear ✕ restored the title and zeroed the selection
- ticking a checkbox did **not** navigate; clicking the row still did
- selecting an already-archived row (via the archived filter chip) was refused client-side with a message, no request sent
- 320px viewport: no toolbar or page overflow
- `tsc --noEmit` clean

## Related Issues

Part of #820.

**On the mass-delete half of that issue** — left out deliberately, and I think it needs a backend decision first. `DELETE /Election/:id` exists and is owner/system_admin gated, but nothing in the frontend calls it, and `deleteElectionController` calls `ElectionsModel.delete()`, which removes rows from `electionDB` only. The transactional `deleteAllElectionData()` right below it in `Models/Elections.ts` — the one that also clears `ballotDB` and `electionRollDB` — currently has no callers anywhere in the repo. So wiring a mass-delete button to today's endpoint would orphan ballots and voter rolls in bulk. Happy to open a separate issue or PR for that if you'd like it fixed; the table-side work here is method-agnostic and a `Delete` entry would drop straight into the same Actions menu once the backend is settled.
