### PR TITLE
docs: group the help pages into three sections

### DIFF
--- a/docs/help/counting_and_results.md
+++ b/docs/help/counting_and_results.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Counting and Results
+nav_order: 2
+parent: BetterVoting Documentation
+has_children: true
+---
+
+# Counting and Results
+
+How votes are counted, what you can share while voting is still open, and how ties are resolved.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2,7 +2,8 @@
 layout: default
 title: Frequently Asked Questions
 nav_order: 99
-parent: BetterVoting Documentation
+parent: Reference
+grand_parent: BetterVoting Documentation
 ---
 
 # Frequently Asked Questions

--- a/docs/help/hand_count.md
+++ b/docs/help/hand_count.md
@@ -2,7 +2,8 @@
 layout: default
 title: Hand Count
 nav_order: 6
-parent: BetterVoting Documentation
+parent: Counting and Results
+grand_parent: BetterVoting Documentation
 ---
 
 Modern elections can sometimes feel like a black box between the voting machines, proprietary software, and for-profit elections vendors. For these reasons and more, many jurisdictions (and some entire countries) still opt to tally their elections the old fashioned way: hand counting the ballots. Even for those who do opt for automated election tallying, hand counted partial recounts and audits are are great way to cross check systems and ensure that everything is working as it should. 

--- a/docs/help/how_to_enable_beta_features.md
+++ b/docs/help/how_to_enable_beta_features.md
@@ -2,7 +2,8 @@
 layout: default
 title: How to enable beta features
 nav_order: 99
-parent: BetterVoting Documentation
+parent: Reference
+grand_parent: BetterVoting Documentation
 ---
 
 # How to enable beta features

--- a/docs/help/paper_ballots.md
+++ b/docs/help/paper_ballots.md
@@ -2,7 +2,8 @@
 layout: default
 title: Paper Ballots
 nav_order: 5
-parent: BetterVoting Documentation
+parent: Setting Up Your Election
+grand_parent: BetterVoting Documentation
 ---
 
 {:toc}

--- a/docs/help/preliminary_results.md
+++ b/docs/help/preliminary_results.md
@@ -2,7 +2,8 @@
 layout: default
 title: Preliminary Results
 nav_order: 8
-parent: BetterVoting Documentation
+parent: Counting and Results
+grand_parent: BetterVoting Documentation
 ---
 
 # Preliminary Results

--- a/docs/help/reference.md
+++ b/docs/help/reference.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Reference
+nav_order: 3
+parent: BetterVoting Documentation
+has_children: true
+---
+
+# Reference
+
+Answers to common questions, and settings that aren't part of the normal setup flow.

--- a/docs/help/security_options.md
+++ b/docs/help/security_options.md
@@ -2,7 +2,8 @@
 layout: default
 title: Security Options
 nav_order: 7
-parent: BetterVoting Documentation
+parent: Setting Up Your Election
+grand_parent: BetterVoting Documentation
 ---
 
 # BetterVoting Security Options

--- a/docs/help/setting_up.md
+++ b/docs/help/setting_up.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Setting Up Your Election
+nav_order: 1
+parent: BetterVoting Documentation
+has_children: true
+---
+
+# Setting Up Your Election
+
+Everything you decide before voting opens — who can vote, how ballots reach them, and what happens as your election moves from a draft to a live vote.

--- a/docs/help/ties.md
+++ b/docs/help/ties.md
@@ -2,7 +2,8 @@
 layout: default
 title: Ties
 nav_order: 6
-parent: BetterVoting Documentation
+parent: Counting and Results
+grand_parent: BetterVoting Documentation
 ---
 
 {:toc}


### PR DESCRIPTION
**Draft — this is a proposal for discussion, not something that needs merging soon.** Opening it as a PR rather than an issue because the shape is easier to judge when you can see it rendered.

Groups the help pages into three sections, following the election lifecycle:

| Section | Pages |
|:---|:---|
| **Setting Up Your Election** | Paper Ballots, Security Options |
| **Counting and Results** | Hand Count, Ties, Preliminary Results |
| **Reference** | FAQ, How to enable beta features |

```
BetterVoting Documentation
    Setting Up Your Election
        Paper Ballots
        Security Options
    Counting and Results
        Hand Count
        Ties
        Preliminary Results
    Reference
        Frequently Asked Questions
        How to enable beta features
```

## No files move and no URLs change

This is the part that makes it cheap to try. just-the-docs builds the sidebar from `parent:` front matter, **not** from directory layout — `index.md` at the docs root is already the parent of `help/faq.md` in a subfolder, so nesting is independent of where files live.

So every page keeps its exact URL, including the six the app hardcodes and both deep anchors. Verified against a local build:

- `/help/paper_ballots.html`, `/help/hand_count.html`, `/help/ties.html`, `/help/faq.html`, `/help/preliminary_results.html` — all unchanged
- `ties.html#random-tie-breakers` and `faq.html#write-in-scores-not-counted` — both anchors still present

It's also reversible with a one-line edit per page, which is why it seemed worth showing rather than just describing.

## Why now, given there are only seven pages

Honestly: at this size a flat list is arguably better, and **if that's the conclusion, closing this is a perfectly good outcome.**

The reason to settle it now is the backlog — there's a lot of help content written but unpublished, and agreeing where things go *before* writing avoids re-litigating placement on every content PR. The grouping follows the election lifecycle (before the vote → during and after → reference), which is what Simply Voting's help site uses and what BV's own election states map onto naturally.

## Interaction with #1502

[#1502](https://github.com/Equal-Vote/bettervoting/pull/1502) adds an Election States page with `parent: BetterVoting Documentation`. If both are wanted, whichever merges second needs a one-line front-matter update — Election States belongs under **Setting Up Your Election**. Happy to rebase whichever way suits; they're otherwise independent.

## Background

I sketched this out while looking at how other election platforms organise their help sites (Simply Voting, ElectionBuddy, Election Runner, VotingApp). Those notes are [here](https://github.com/masiarek/star-voting-library/blob/master/07_Concepts/tabulation_engines/BV/bv_docs_information_architecture.md) if the reasoning is useful — they're working notes rather than a polished proposal, so they're blunt in places, and the specific nav in them is more ambitious than what this PR does.
