### PR TITLE
fix(results): move the winner title into en.yaml, stars included

### DIFF
--- a/packages/frontend/src/components/Election/Results/Results.tsx
+++ b/packages/frontend/src/components/Election/Results/Results.tsx
@@ -457,11 +457,10 @@ export default function Results({ race, results }: {race: Race, results: Electio
     const learnLinkKey = `methods.${methodKey}.learn_link`;
     const votingMethod= t(`methods.${methodKey}.full_name`)
 
+    // Non-breaking spaces inside each name keep a candidate's name on one line,
+    // while the separators added by commaListFormatter stay breakable.
     const winnersText = commaListFormatter
-    .format(results.elected.map(c => c.name.replace(' ', '__REPLACE_ME__')))
-    .split('__REPLACE_ME__')
-    .map((s,i) => ([<React.Fragment key={i*2}>{s}</React.Fragment>, <React.Fragment key={i*2+1}>&nbsp;</React.Fragment>]))
-    .flat()
+    .format(results.elected.map(c => c.name.replace(/ /g, '\u00A0')));
   // this is not exact, but it's enough to judge the threshold
   const winnersLength = results.elected.map(c => c.name).join(' ').length;
   
@@ -474,7 +473,7 @@ export default function Results({ race, results }: {race: Race, results: Electio
       <div className="flexContainer" style={{textAlign: 'center'}}>
         <Box sx={{pageBreakAfter:'avoid', pageBreakInside:'avoid', mx: 10}}>
         {results.summaryData.candidates.length === 1 && <>
-          <Typography variant='h5'>⭐ {results.summaryData.candidates[0].name} wins uncontested ⭐</Typography>
+          <Typography variant='h5'>{t('results.win_uncontested_title', {name: results.summaryData.candidates[0].name.replace(/ /g, '\u00A0')})}</Typography>
           {results.writeInDiagnostics?.numScoresDisregarded > 0 &&
             <Typography component="p" sx={{color: '#808080', fontSize: '0.9rem', mt: 1}}>
               {results.writeInDiagnostics.numScoresDisregarded} write-in score{results.writeInDiagnostics.numScoresDisregarded === 1 ? '' : 's'} not counted.{' '}
@@ -495,7 +494,7 @@ export default function Results({ race, results }: {race: Race, results: Electio
           :
             <Typography variant='h5'>
             {(winnersLength < 80) ? 
-              <>⭐ {winnersText}{t('results.win_title_postfix', {count: results.elected.length})} ⭐</>
+              t('results.win_title', {names: winnersText, count: results.elected.length})
             :
               [t('results.win_long_title_prefix'), ...results.elected.map(elected => ([<br key={elected.index}/>, `${elected.name}`])).flat()]
             }

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -246,9 +246,10 @@ results:
     No votes have been cast
   tie_title: 'Tied!'
   random_tiebreak_subtitle: '{{names}} won after tiebreaker !tip(random_tie_order)'
-  win_long_title_prefix: '⭐Winners⭐'
-  win_title_postfix_one: 'wins!'
-  win_title_postfix: 'win!'
+  win_long_title_prefix: '⭐ Winners ⭐'
+  win_uncontested_title: '⭐ {{name}} wins uncontested ⭐'
+  win_title_one: '⭐ {{names}} wins! ⭐'
+  win_title: '⭐ {{names}} win! ⭐'
   vote_count: '{{n}} voters'
   method_context: 'Voting Method: {{voting_method}}'
   learn_link_text: How {{voting_method}} works

--- a/packages/frontend/src/i18n/es.yaml
+++ b/packages/frontend/src/i18n/es.yaml
@@ -204,8 +204,8 @@ results:
     Los resultados totales serán mostrados una vez se hayan emitido más votos.
   tie_title: '¡Empate!'
   random_tiebreak_subtitle: '{{names}} ganó después de un desempate.'
-  win_title_postfix_one: '¡Gana!'
-  win_title_postfix: '¡Ganan!'
+  win_title_one: '⭐ {{names}} ¡Gana! ⭐'
+  win_title: '⭐ {{names}} ¡Ganan! ⭐'
   vote_count: '{{n}} votantes'
   method_context: 'Método de votación: {{voting_method}}'
   learn_link_text: Cómo {{voting_method}} funciona

--- a/packages/frontend/src/i18n/pl.yaml
+++ b/packages/frontend/src/i18n/pl.yaml
@@ -194,8 +194,8 @@ results:
     Full results will be displayed once there's more votes.
   tie_title: 'Tied!'
   random_tiebreak_subtitle: '{{names}} won after tie breaker'
-  win_title_postfix_one: 'Wins!'
-  win_title_postfix: 'Win!'
+  win_title_one: '⭐ {{names}} Wins! ⭐'
+  win_title: '⭐ {{names}} Win! ⭐'
   vote_count: '{{n}} voters'
   method_context: 'Voting Method: {{voting_method}}'
   learn_link_text: How {{voting_method}} works

--- a/packages/frontend/src/i18n/pt-BR.yaml
+++ b/packages/frontend/src/i18n/pt-BR.yaml
@@ -196,8 +196,8 @@ results:
     Os resultados completos serão exibidos quando houver mais votos.
   tie_title: 'Empate!'
   random_tiebreak_subtitle: '{{names}} venceu após o desempate'
-  win_title_postfix_one: 'Vence!'
-  win_title_postfix: 'Vencem!'
+  win_title_one: '⭐ {{names}} Vence! ⭐'
+  win_title: '⭐ {{names}} Vencem! ⭐'
   vote_count: '{{n}} eleitores'
   method_context: 'Método de Votação: {{voting_method}}'
   learn_link_text: Como {{voting_method}} funciona


### PR DESCRIPTION
## Description

Second action item of #1233: *"Move the whole format string including emojis to en.yaml file if possible rather than interleaving in code."*

**The padding half is already fixed on `main`** — commit 11a8facf ("Add padding around emojis") added the missing space after the left star, and I confirmed it renders symmetrically today: the two text nodes `"⭐ "` and `" ⭐"` measure 31.0 px each on the winner line. So this PR is only the second half, which is what keeps the first half from regressing: the string lives somewhere a person can see it.

What changed:

- **`results.win_title` / `win_title_one`** — the whole line, both stars included, now lives in the locale file. The other three locales get the same key built from the wording they already had (`¡Gana!`, `Vence!`, `Wins!`), so nothing changes on screen for them.
- **`results.win_uncontested_title`** — the "⭐ X wins uncontested ⭐" line was hardcoded English in `Results.tsx` and had never been translatable at all. Now it is.
- **`win_long_title_prefix`** padded to match: `⭐ Winners ⭐`.
- The `__REPLACE_ME__` / `React.Fragment` dance that injected `&nbsp;` is replaced by a plain ` ` substitution. The old version replaced only the *first* space of each name and appended a stray `&nbsp;` after the last one; the new one keeps every candidate name unbroken and leaves the comma separators breakable.

No behaviour change intended — the rendered string is byte-identical to what `main` produces.

### Verification

- `tsc --noEmit` clean.
- Rendered `results.win_title` through i18next for `count: 1` and `count: 2` in all four locales, including the Polish plural path that falls back to the base key:

```
en     "⭐ Ann Ambitious wins! ⭐"       "⭐ Ann Ambitious, Bob Bossy win! ⭐"
es     "⭐ Ann Ambitious ¡Gana! ⭐"      "⭐ Ann Ambitious, Bob Bossy ¡Ganan! ⭐"
pl     "⭐ Ann Ambitious Wins! ⭐"       "⭐ Ann Ambitious, Bob Bossy Win! ⭐"
pt-BR  "⭐ Ann Ambitious Vence! ⭐"      "⭐ Ann Ambitious, Bob Bossy Vencem! ⭐"
```

- Checked on a local election (STAR, 3 candidates, 10 ballots) at desktop 1280 and mobile 390.

## Screenshots / Videos (frontend only)

Desktop and mobile of the winner line, rendered from the new key — visually identical to `main`:

**Desktop (1280)**

<img width="760" alt="Winner line reading star Ann Ambitious wins! star, with equal spacing on both sides" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1233_desktop_headline.png">

**Mobile (390)**

<img width="330" alt="Winner line on a 390px viewport" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1233_mobile_headline.png">


## Related Issues

Fixes #1233
