### PR TITLE
fix(results): name Equal Support in the runoff footnote

### DIFF
--- a/packages/frontend/src/components/Election/Results/STAR/STARResultSummaryWidget.tsx
+++ b/packages/frontend/src/components/Election/Results/STAR/STARResultSummaryWidget.tsx
@@ -50,15 +50,15 @@ const STARResultSummaryWidget = ({ results, roundIndex, t }: {results: starResul
         votes: c.votesPreferredOver[finalists[1-i].id]
     }));
 
-    const noPreferenceVotes = results.summaryData.nTallyVotes - pieData[0].votes - pieData[1].votes;
-    const noPreferencePercentage = results.summaryData.nTallyVotes > 0 
-        ? (noPreferenceVotes / results.summaryData.nTallyVotes * 100).toFixed(1)
+    const equalSupportVotes = results.summaryData.nTallyVotes - pieData[0].votes - pieData[1].votes;
+    const equalSupportPercentage = results.summaryData.nTallyVotes > 0 
+        ? (equalSupportVotes / results.summaryData.nTallyVotes * 100).toFixed(1)
         : '0.0';
 
     const runoffData = [...pieData]
     runoffData.push({
       name: t('results.star.equal_preferences'),
-      votes: noPreferenceVotes,
+      votes: equalSupportVotes,
     })
 
     return (
@@ -79,7 +79,7 @@ const STARResultSummaryWidget = ({ results, roundIndex, t }: {results: starResul
                     <>
                         <ResultsPieChart data={pieData} star runoff/>
                         <Typography variant="body2" sx={{ fontStyle: 'italic', textAlign: 'center', mt: 1 }}>
-                            {t('results.star.runoff_no_preference_footnote', { percentage: noPreferencePercentage })}
+                            {t('results.star.runoff_equal_support_footnote', { percentage: equalSupportPercentage })}
                         </Typography>
                     </>
                 :

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -301,8 +301,8 @@ results:
     runoff_description:
       - Each vote goes to the voter's preferred finalist.
       - Finalist with most votes wins.
-    runoff_majority: majority threshold (½ of voters with preference)
-    runoff_no_preference_footnote: "{{percentage}}% of voters expressed no preference between the two finalists."
+    runoff_majority: majority threshold (½ of voters with a preference)
+    runoff_equal_support_footnote: "{{percentage}}% of voters gave both finalists the same score ($t(results.star.equal_preferences))."
     score_table_title: Scores Table
     score_table_columns:
       - '{{capital_candidate}}'


### PR DESCRIPTION
## Description

Closes #1456 — one STAR results screen described the same bucket two ways: the runoff table and bar chart label it **Equal Support**, while the pie chart's footnote called it *"no preference"*. A first-time reader can reasonably read those as two different things.

- **`runoff_equal_support_footnote`** (renamed from `runoff_no_preference_footnote`) now says what the ballot did and names the term:

  > 12.5% of voters gave both finalists the same score (Equal Support).

  The term is pulled in with `$t(results.star.equal_preferences)` rather than hardcoded, so a locale that has already translated "Equal Support" gets *its own* word here even while the surrounding sentence is still falling back to English — `es` renders *(Apoyo igualitario)*, `pt-BR` *(Preferências Iguais)*.
- **`runoff_majority`**: "½ of voters with **a** preference" (article added).
- Renamed the two local variables in `STARResultSummaryWidget` (`noPreferenceVotes` → `equalSupportVotes`) so the code uses the term the UI uses.

`en.yaml` only — no other locale had the footnote key.

### Verification

- `tsc --noEmit` clean.
- Resolved the string in all four locales; checked on a local STAR election with 1 of 8 voters scoring both finalists equally (12.5%), desktop 1280 and mobile 390.

### Not in scope, but noticed

On the same panel the pie itself draws only the two finalists — the Equal Support share is simply missing from the circle (12.5% of the pie is empty), which is part of why the footnote has to carry it. Happy to open a separate issue if that isn't already tracked.

## Screenshots / Videos (frontend only)

**Desktop (1280)**

<img width="760" alt="Runoff pie with the footnote 12.5% of voters gave both finalists the same score (Equal Support)" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1456_desktop_runoff.png">

**Mobile (390)**

<img width="330" alt="Same footnote on a 390px viewport" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1456_mobile_runoff.png">


## Related Issues

Closes #1456
