### PR TITLE
fix(results): print the ballot count on Range of Scores

### DIFF
--- a/packages/frontend/src/components/Election/Results/components/ScoreRangeWidget.tsx
+++ b/packages/frontend/src/components/Election/Results/components/ScoreRangeWidget.tsx
@@ -7,7 +7,7 @@ import ResultsBarChart from "./ResultsBarChart";
 // candidates helps define the order
 const ScoreRangeWidget = () => {
     const {ballotsForRace} = useAnonymizedBallots();
-    const {t} = useRace();
+    const {t, results} = useRace();
 
     const numAtDiff = [];
 
@@ -22,16 +22,27 @@ const ScoreRangeWidget = () => {
         arr[index].count++;
     }
 
-    ballotsForRace().forEach((scores) => {
+    const ballots = ballotsForRace();
+
+    ballots.forEach((scores) => {
         incIndex(numAtDiff,
             scores.reduce((prev,score) => Math.max(prev, score.score), 0) - 
             scores.reduce((prev,score) => Math.min(prev, score.score), 20)
         )
     })
 
+    // This chart histograms every ballot that scored at least one candidate,
+    // while the tabulation drops ballots that gave every candidate the same
+    // score. Say both numbers out loud rather than leaving the percentages
+    // sitting on an invisible denominator.
+    const nAbstentions = Math.max(0, ballots.length - results.summaryData.nTallyVotes);
+
     return <Widget title={t(`results_ext.score_range_title`)}>
-        <Typography variant='h6'>{t(`results_ext.score_range_sub_title`)}</Typography>
+        <Typography variant='h6'>{t(`results_ext.score_range_sub_title`, {count: ballots.length})}</Typography>
         <ResultsBarChart data={numAtDiff.reverse()} xKey='count' percentage={true}/>
+        {nAbstentions > 0 &&
+            <Typography sx={{'textAlign': 'left'}}>{t(`results_ext.score_range_abstention_note`, {count: nAbstentions})}</Typography>
+        }
         <Typography sx={{'textAlign': 'left'}}>{t(`results_ext.score_range_warning`)}</Typography>
     </Widget>
 }

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -628,7 +628,10 @@ results_ext:
     most familiar with.
 
   score_range_title: Range of Scores
-  score_range_sub_title: Difference between maximum and minimum score on ballots
+  score_range_sub_title_one: 'Difference between maximum and minimum score on ballots ({{count}} ballot)'
+  score_range_sub_title: 'Difference between maximum and minimum score on ballots ({{count}} ballots)'
+  score_range_abstention_note_one: 'This chart also counts {{count}} ballot that gave every candidate the same score. The tabulation treats that as an abstention, which is why the voter count at the top of the page is lower.'
+  score_range_abstention_note: 'This chart also counts {{count}} ballots that gave every candidate the same score. The tabulation treats those as abstentions, which is why the voter count at the top of the page is lower.'
   score_range_warning: > 
     In order to have a maximum impact on the scoring round of STAR Voting, voters need to 
     follow the instructions on the ballot and indicate at at least one zero (or blank),


### PR DESCRIPTION
## Description

Closes #1487. The **Range of Scores** chart histograms `max − min` over every ballot that scored at least one candidate, while the tabulator drops a ballot that gave every candidate the same score (#884). On a race with flat ballots the two disagree, and the chart's percentages were shown against a denominator that appeared nowhere on the page — on the 3-ballot example in the issue, the tall "67%" bar is composed entirely of the two ballots the same page has already declared abstentions.

As the issue argues, the chart's denominator is arguably the **right** one for the question it asks ("did voters use the full 0–5 range?" is a question about ballots as marked, and a flat ballot is the most extreme case of not using the range). So this does not change what is counted — it says the number out loud:

- The subtitle carries the count: *"Difference between maximum and minimum score on ballots (10 ballots)"*.
- When that count differs from `nTallyVotes`, one line names the gap: *"This chart also counts 2 ballots that gave every candidate the same score. The tabulation treats those as abstentions, which is why the voter count at the top of the page is lower."* — it does not render at all when the two agree, which is the normal case.

Both strings are plural-aware (`_one` / base key), matching the convention already used in `en.yaml`.

The widget is behind the `ALL_STATS` flag, so this is a fix **before** the panel ships rather than a live user-facing change.

### Verification

- `tsc --noEmit` clean.
- Local STAR election, 3 candidates, 10 ballots, 2 of them flat (`3,3,3` and `2,2,2`). Headline reads "8 voters"; the chart now reads "(10 ballots)" and prints the note with `2`. Checked at desktop 1280 and mobile 390 with `flag_overrides = {"ALL_STATS": true}`.

### Follow-up left alone

The issue's third action item — auditing the other Stats for Nerds widgets (Column Distribution, Voter Profile, Name Recognition, Head-to-head), which all read the same `ballotsForRace()` helper — is not in this PR. Each one needs its own judgement about which denominator is right for the question it asks, and I'd rather not answer that in a labelling change.

## Screenshots / Videos (frontend only)

**Desktop (1280)**

<img width="760" alt="Range of Scores chart with the subtitle ending in (10 ballots) and the abstention note below it" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1487_desktop_scorerange.png">

**Mobile (390)**

<img width="330" alt="Same chart on a 390px viewport" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1487_mobile_scorerange.png">


## Related Issues

Closes #1487
