### PR TITLE
fix(i18n): fix the typos on the Range of Scores panel

### DIFF
--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -631,8 +631,8 @@ results_ext:
   score_range_sub_title: Difference between maximum and minimum score on ballots
   score_range_warning: > 
     In order to have a maximum impact on the scoring round of STAR Voting, voters need to 
-    follow the instructions on the ballot and indicate at at least one zero (or blank),
-    and at least one five. This would result in a range of 5 for the voters scores.
+    follow the instructions on the ballot and indicate at least one zero (or blank),
+    and at least one five. This would result in a range of 5 for the voter's scores.
 
 
     That said their ballot will still make a full impact during the automatic runoff where 
@@ -641,10 +641,10 @@ results_ext:
 
     Voters who didn't use the full range, either didn't understand the instructions or chose
     to use a smaller range on purpose. This could be as a protest vote expressing that no candidates deserve 5 stars,
-    or it could be the opposite choosing to express that they have a postive opinion of everyone.
+    or it could be the opposite, choosing to express that they have a positive opinion of everyone.
 
 
-    Note that not the consequences for not following the instructions are relatively minor, whereas failing to follow
+    Note that the consequences for not following the instructions are relatively minor, whereas failing to follow
     the instructions in RCV could get your ballot thrown out (like giving multiple candidates your first choice). Voters
     are also far more likely to use the full range in political elections where voters have a strong opinion.
 


### PR DESCRIPTION
## Description

Closes #1186 — the five spots highlighted in the screenshot on that issue, all inside `results_ext.score_range_warning`:

| Before | After |
|---|---|
| indicate **at at** least one zero | indicate at least one zero |
| a range of 5 for the **voters scores** | a range of 5 for the **voter's** scores |
| it could be the **opposite choosing** to express | it could be the **opposite, choosing** to express |
| a **postive** opinion of everyone | a **positive** opinion of everyone |
| **Note that not the** consequences … are relatively minor | **Note that the** consequences … are relatively minor |

Text only, `en.yaml` only, no code touched. The last one was the one that actually breaks the sentence — as written it says the opposite of what it means.

I did not have access to the Google Doc referenced on the issue (still not publicly viewable, per @ArendPeter's comment), so this is scoped to what is legible in the attached screenshot. If the doc lists more, point me at it and I'll fold them in.

### Verification

Rendered on a local dev stack with `flag_overrides = {"ALL_STATS": true}` — the panel is behind that flag, as noted on the issue.

## Screenshots / Videos (frontend only)

**Desktop (1280)**

<img width="620" alt="The Range of Scores explanatory text with all five corrections applied" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1186_desktop_warning.png">

**Mobile (390)**

<img width="300" alt="The same text on a 390px viewport" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1186_mobile_warning.png">

## Related Issues

Closes #1186
