### PR TITLE
feat(results): show when the election was created

### DIFF
--- a/packages/frontend/src/components/Election/Results/ViewElectionResults.tsx
+++ b/packages/frontend/src/components/Election/Results/ViewElectionResults.tsx
@@ -45,6 +45,14 @@ const ViewElectionResults = () => {
             <Typography variant="h4" component="h4">
               {t("results.election_title", { title: election.title })}
             </Typography>
+            {election.create_date && (
+              <Typography
+                component="p"
+                sx={{ color: "#808080", fontSize: "0.9rem", mt: 1 }}
+              >
+                {t("results.created_date", { listed_datetime: election.create_date })}
+              </Typography>
+            )}
 
             {isPending && <div> {t("results.loading_election")} </div>}
             {!election.settings.public_results && (

--- a/packages/frontend/src/components/Elections/ElectionsYouManage.tsx
+++ b/packages/frontend/src/components/Elections/ElectionsYouManage.tsx
@@ -76,7 +76,7 @@ const ElectionsYouManage = () => {
             
     return <EnhancedTable
         title='My Elections & Polls'
-        headKeys={['title', 'update_date', 'election_state', 'start_time', 'end_time', 'description']}
+        headKeys={['title', 'create_date', 'update_date', 'election_state', 'start_time', 'end_time', 'description']}
         isPending={isPending || !authSession.isLoggedIn() || electionToClaim}
         pendingMessage='Loading Elections...'
         data={managedElectionsData}

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -233,6 +233,7 @@ results:
   election_title: |
     {{capital_election}} Name:
     {{title}}
+  created_date: '{{capital_election}} created {{listed_datetime, datetime}}'
   race_title: '{{capital_race}} {{n}}: {{title}}'
   single_candidate_result: '{{name}} is the only {{candidate}}, and wins by default'
   loading_election: Loading {{capital_election}}...


### PR DESCRIPTION
## Description

Closes #1472 — action items 1 and 2. `create_date` was reachable only by curling the API; now it is on the two screens where someone actually asks the question.

**Results page.** A small line under the election name:

> Election created 8/13/2026, 8:00 PM

It uses the existing top-level `listed_datetime` key, so formatting and timezone handling match the rest of the app, and it goes through the `term_type` keyword — a poll reads *"Poll created …"*. It renders only when `create_date` is present. This is the half that matters for public and archived results, where a reader needs provenance for a count they did not run themselves.

**"My Elections & Polls".** One entry added to the `headKeys` array. The `create_date` column was already fully defined in `EnhancedTable`'s column pool — label with local timezone, `isDate` for sorting, `listed_datetime` formatter — and is already in use by `/query_tool`, so nothing new had to be defined.

`update_date` is not a substitute for either: it bumps on every edit and every state transition, so for any election touched since creation it says nothing about when the election began.

### Deliberately left out

- **`/browse` and `/public_archive`** (the issue lists these as *"consider"*). Those tables are for picking an election to vote in or read; creation time is noise there, and each extra column costs width. Happy to add them if you disagree.
- **The optional admin-home "Election details" block** (action item 3) — a bigger design call than a date line.

### Verification

- `tsc --noEmit` clean.
- Results-page line rendered on a local dev stack against a seeded election, desktop 1280 and mobile 390 (screenshots below).
- **Not clicked through:** the "My Elections & Polls" table itself, which needs a logged-in session owning elections — more than my local Keycloak setup gives me cheaply. What I did check is that the column definition renders: `/query_tool` uses the same `create_date` key and its header comes up as *"Create Date (EDT)"* (third screenshot). The change there is one string in an array, and the field is the same ISO `create_date` that column already consumes.

## Screenshots / Videos (frontend only)

**Desktop (1280)** — results page

<img width="700" alt="Results page header with a line reading Election created 8/13/2026, 8:00 PM under the election name" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1472_desktop_created.png">

**Mobile (390)**

<img width="300" alt="The same created line on a 390px viewport" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1472_mobile_created.png">

**The column definition, already live in `/query_tool`**

<img width="700" alt="Query tool table showing a Create Date (EDT) column header" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1472_desktop_querytool.png">

## Related Issues

Closes #1472
