### PR TITLE
fix(ci): don't ping issues that already have an open PR (and unbreak the bot)

### DIFF
--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@octokit/rest": "^20.0.2",
-        "@types/node": "^20.10.0",
+        "@types/node": "^24.0.0",
         "dotenv": "^16.4.5"
       },
       "devDependencies": {
-        "typescript": "^5.3.0"
+        "typescript": "^5.9.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -172,12 +172,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/before-after-hook": {
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {

--- a/.github/scripts/src/issue-management/StaleIssueChecker.ts
+++ b/.github/scripts/src/issue-management/StaleIssueChecker.ts
@@ -155,6 +155,63 @@ If you need help, please request for assistance on the #bettervoting slack chann
   }
 
   /**
+   * Find open pull requests in this repository that reference the issue.
+   *
+   * A PR referencing an issue does not bump that issue's updated_at, so an issue
+   * whose fix is already sitting in review still looks stale to the check above
+   * (see #1296, which was pinged twice while its PR was open).
+   */
+  private async getOpenLinkedPullRequests(issueNumber: number): Promise<number[]> {
+    const referenced = new Set<number>();
+    let page = 1;
+
+    while (true) {
+      const timeline = await this.octokit.issues.listEventsForTimeline({
+        owner: this.config.owner,
+        repo: this.config.repo,
+        issue_number: issueNumber,
+        per_page: 100,
+        page: page,
+      });
+
+      if (timeline.data.length === 0) break;
+
+      for (const event of timeline.data) {
+        if (event.event !== 'cross-referenced') continue;
+
+        // A cross-reference can come from an issue rather than a PR, and from
+        // another repository. Only same-repo pull requests count.
+        const source = (event as any).source?.issue;
+        if (!source?.pull_request) continue;
+        if (source.repository?.full_name &&
+            source.repository.full_name !== `${this.config.owner}/${this.config.repo}`) continue;
+
+        referenced.add(source.number);
+      }
+
+      page++;
+    }
+
+    const open: number[] = [];
+    for (const pullNumber of referenced) {
+      try {
+        const pull = await this.octokit.pulls.get({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          pull_number: pullNumber,
+        });
+        // Re-read the state rather than trusting the timeline's copy, which is a
+        // snapshot from when the reference was made.
+        if (pull.data.state === 'open') open.push(pullNumber);
+      } catch (error) {
+        console.error(`  ⚠️  Could not read PR #${pullNumber} linked from issue #${issueNumber}:`, error);
+      }
+    }
+
+    return open.sort((a, b) => a - b);
+  }
+
+  /**
    * Check stale status for assigned issues
    */
   async checkStaleIssues(issues: IssueData[]): Promise<{ warnings: number; inactive: number }> {
@@ -173,6 +230,16 @@ If you need help, please request for assistance on the #bettervoting slack chann
       console.log(`\n  Checking issue #${issue.number}: ${issue.title}`);
       console.log(`    Last updated: ${ageDisplay}`);
       console.log(`    Assignees: ${issue.assignees.map(a => a.login).join(', ')}`);
+
+      // Only pay for the timeline lookup on issues that are about to be actioned.
+      if (timeSinceUpdate >= this.config.warningWeeks) {
+        const openPullRequests = await this.getOpenLinkedPullRequests(issue.number);
+        if (openPullRequests.length > 0) {
+          const list = openPullRequests.map(n => `#${n}`).join(', ');
+          console.log(`    ⏭️  Open pull request${openPullRequests.length === 1 ? '' : 's'} ${list} — skipping (${ageDisplay})`);
+          continue;
+        }
+      }
 
       if (timeSinceUpdate >= this.config.unassignWeeks) {
         // Issue should get inactive label

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -47,6 +47,9 @@ jobs:
     permissions:
       issues: write
       contents: read
+      # read-only, so the stale check can see whether an issue already has an
+      # open pull request
+      pull-requests: read
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

Closes #1315 — and, found on the way, **the bot has not run at all since 9 June**.

### 1. The workflow itself is broken (first commit)

`.github/scripts/package-lock.json` fell out of sync with its `package.json` in `bd269431` ("remove dead deps", 22 May), so the workflow dies at its `npm ci` step before any of the logic runs:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Invalid: lock file's @types/node@20.19.1 does not satisfy @types/node@24.13.3
npm error Invalid: lock file's typescript@5.8.3 does not satisfy typescript@5.9.3
npm error Invalid: lock file's undici-types@6.21.0 does not satisfy undici-types@7.18.2
```

Every scheduled run since **2026-06-09** has failed this way — 66 consecutive failures ([latest](https://github.com/Equal-Vote/bettervoting/actions/runs/31789952947)). Regenerated the lock with `npm install`; `npm ci` and `npm run build` both succeed against it. Happy to split this into its own PR if you'd rather, but #1315 can't be verified without it.

### 2. Skip issues that already have an open PR (second commit)

The staleness signal is `issue.updated_at`, and **a PR that references an issue does not bump it**. So an issue whose fix is sitting in review keeps ageing, collects the *"🤖 Check-In Reminder"*, and is eventually labelled `2 weeks inactive` — exactly what happened on #1296.

`StaleIssueChecker` now:

- reads the issue timeline for `cross-referenced` events,
- keeps the ones whose source is a **pull request in this repository** (a cross-reference can come from an issue, or from another repo),
- asks the API for each PR's **current** state rather than trusting the timeline's snapshot,
- and if any is open, skips the issue for *both* the warning comment and the inactive label, logging which PR spared it.

The lookup runs only for issues already past the warning threshold, so it costs nothing for the assigned issues that are still active. Reading PRs needs a permission the job did not have, so it now also declares `pull-requests: read`.

### Verification

`npm run build` clean, and a **dry run against the live repository** (`DRY_RUN=true`, read-only — every mutating call short-circuits) over all 417 open issues, 49 of them assigned. Six issues that would otherwise be warned or labelled today were skipped:

```
Checking issue #1481: Backend test suite flakes ~1 run in 12 ...
  ⏭️  Open pull request #1491 — skipping (1 weeks ago)
Checking issue #1443: Add yearly, per-method breakdown to GlobalElectionStats API
  ⏭️  Open pull request #1445 — skipping (3 weeks ago)
Checking issue #1425: Reduce tabulation memory ...
  ⏭️  Open pull request #1464 — skipping (2 weeks ago)
Checking issue #1350: Add a disclaimer related to preliminary results
  ⏭️  Open pull request #1466 — skipping (2 weeks ago)
Checking issue #1219: Add transactional checkbox within email creation flow
  ⏭️  Open pull request #1463 — skipping (2 weeks ago)
Checking issue #762:  Add Polish translation - BetterVoting website
  ⏭️  Open pull request #1476 — skipping (2 weeks ago)
```

### Judgement calls worth a review opinion

- **Draft PRs count as open.** A draft is still "the PR is out", and treating it otherwise means pinging someone who is visibly working. If you'd rather a draft not suppress the reminder, it's a one-line change.
- **The reminder text still says "even if you have a pull request".** That now only applies to a closed or merged PR. Left alone deliberately — happy to reword it here if you want.
- Not touched: `hasWarningComment` still matches a legacy string ("This task will auto unassign in 1 week") and the README still describes auto-unassigning, though the code only labels. Separate cleanup.

## Related Issues

Closes #1315
