### PR TITLE
fix(sandbox): say when a score is outside the method's range

### DIFF
--- a/packages/frontend/src/components/Sandbox.tsx
+++ b/packages/frontend/src/components/Sandbox.tsx
@@ -11,6 +11,30 @@ import { VotingMethod } from '@equal-vote/star-vote-shared/domain_model/Race';
 import { ElectionContextProvider } from './ElectionContextProvider';
 import { PrimaryButton } from './styles';
 
+// The tabulators bound each method's marks — Star.ts and AllocatedScore.ts to
+// 0-5, Approval.ts and Plurality.ts to 0-1 — and a ballot outside those bounds
+// is silently dropped from the count (filterInitialVotes, counted only as
+// nOutOfBoundsVotes). The sandbox has to say so, or the page just shows a
+// smaller election than the one that was typed in.
+//
+// Ranked methods are deliberately absent: their marks are rankings, bounded by
+// max_rankings rather than by 5, and the sandbox sets no election settings, so
+// any positive rank is legitimate there.
+// null means "not a score at all" — a ranking, bounded by max_rankings rather
+// than by a number, and the sandbox sets no election settings, so any positive
+// rank is legitimate. Spelled as a full Record rather than a Partial so that
+// adding a method to the menu without deciding its range is a type error, not
+// a silent fall-through to no validation.
+const MAX_SCORE_BY_METHOD: Record<VotingMethod, number | null> = {
+    STAR: 5,
+    STAR_PR: 5,
+    Approval: 1,
+    Plurality: 1,
+    RankedRobin: null,
+    IRV: null,
+    STV: null,
+}
+
 const Sandbox = () => {
 
     const { data, error, makeRequest } = useGetSandboxResults()
@@ -31,27 +55,68 @@ const Sandbox = () => {
             setErrorText('Cannot have more winners than candidates')
             return
         }
+        const maxScore = MAX_SCORE_BY_METHOD[votingMethod]
+
+        // The first complaint is the one that gets shown: a later row must not
+        // overwrite it, or a trailing newline reports "wrong length" for a
+        // ballot whose real problem is the score above it.
+        let firstError = ''
+        const fail = (message: string) => { if (firstError === '') firstError = message }
+
+        const checkScores = (marks: string[]) => {
+            for (const mark of marks) {
+                const score = Number(mark)
+                // parseInt would quietly turn 2.5 into 2 and send a ballot the
+                // user never typed, so the raw text is what gets judged.
+                if (!Number.isInteger(score)) {
+                    fail(`You are using incorrect score ${mark}. Scores must be whole numbers.`)
+                    return false
+                }
+                if (score < 0 || (maxScore !== null && score > maxScore)) {
+                    fail(maxScore === null
+                        ? `You are using incorrect score ${score}. Rankings cannot be negative.`
+                        : `You are using incorrect score ${score}. Use scores between 0 and ${maxScore}.`)
+                    return false
+                }
+            }
+            return true
+        }
+
         let valid = true
         cvrRows.forEach((row) => {
+            if (row.trim() === '') return // a trailing newline is not a ballot
             const data = row.split(':')
+            const marks = (data.length == 2 ? data[1] : data[0]).split(/[\s,]+/).filter(d => d !== ' ' && d !== '')
+            const vote = marks.map((score) => parseInt(score)).filter(d => !isNaN(d))
+
+            if (vote.length !== nCandidates) {
+                fail('Each ballot must have the same length as the number of candidates')
+                valid = false
+                return
+            }
+            if (!checkScores(marks)) {
+                valid = false
+                return
+            }
+
             if (data.length == 2) {
                 const nBallots = parseInt(data[0]);
-                const vote = data[1].split(/[\s,]+/).filter(d => d !== ' ').map((score) => parseInt(score)).filter(d => !isNaN(d))
-                if (vote.length !== nCandidates) {
-                    setErrorText('Each ballot must have the same length as the number of candidates')
+                // Array(NaN) and Array(-1) both throw, and the throw escapes an
+                // async effect with no handler, leaving the last error on screen.
+                if (!Number.isInteger(nBallots) || nBallots < 1) {
+                    fail(`'${data[0]}' is not a number of ballots. Use a whole number before the colon.`)
                     valid = false
+                    return
                 }
                 cvrSplit.push(...Array(nBallots).fill(vote))
             } else {
-                const vote = data[0].split(/[\s,]+/).filter(d => d !== ' ').map((score) => parseInt(score)).filter(d => !isNaN(d))
-                if (vote.length !== nCandidates) {
-                    setErrorText('Each ballot must have the same length as the number of candidates')
-                    valid = false
-                }
                 cvrSplit.push(vote)
             }
         })
-        if (!valid) return
+        if (!valid) {
+            setErrorText(firstError)
+            return
+        }
         setErrorText('')
         await makeRequest({
             cvr: cvrSplit,

--- a/packages/frontend/src/components/Sandbox.tsx
+++ b/packages/frontend/src/components/Sandbox.tsx
@@ -87,7 +87,10 @@ const Sandbox = () => {
             if (row.trim() === '') return // a trailing newline is not a ballot
             const data = row.split(':')
             const marks = (data.length == 2 ? data[1] : data[0]).split(/[\s,]+/).filter(d => d !== ' ' && d !== '')
-            const vote = marks.map((score) => parseInt(score)).filter(d => !isNaN(d))
+            // Number, not parseInt, and the same conversion the validation uses:
+            // parseInt('1e2') is 1 where Number is 100, so the two disagreeing
+            // is how a validated mark becomes a different submitted mark.
+            const vote = marks.map(Number)
 
             if (vote.length !== nCandidates) {
                 fail('Each ballot must have the same length as the number of candidates')
@@ -100,7 +103,7 @@ const Sandbox = () => {
             }
 
             if (data.length == 2) {
-                const nBallots = parseInt(data[0]);
+                const nBallots = Number(data[0]);
                 // Array(NaN) and Array(-1) both throw, and the throw escapes an
                 // async effect with no handler, leaving the last error on screen.
                 if (!Number.isInteger(nBallots) || nBallots < 1) {

--- a/testing/tests/sandbox.spec.ts
+++ b/testing/tests/sandbox.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+// Issue #1117: the sandbox forwarded any number to the tabulator, which drops a
+// ballot outside the method's range and counts it only as nOutOfBoundsVotes — so
+// a typo'd 6 quietly produced results for a smaller election than the one typed.
+test.describe('Sandbox score validation', () => {
+    const enter = async (page, ballots: string) => {
+        const votes = page.locator('#cvr');
+        await votes.fill(ballots);
+        await votes.blur();
+        await page.getByRole('button', { name: 'Get Results' }).click();
+    };
+
+    // Results render into the right-hand panel; a winner headline is the cheapest
+    // proof that the request actually went to the tabulator.
+    const results = (page) => page.getByText(/wins!|Tied!/);
+
+    test('rejects a STAR score above 5, and recovers when it is corrected', async ({ page }) => {
+        await page.goto('/sandbox');
+        await expect(page.locator('#cvr')).toBeVisible();
+
+        await enter(page, '5,4,3,2,6');
+        await expect(page.getByText('Use scores between 0 and 5')).toBeVisible();
+
+        await enter(page, '5,4,3,2,1');
+        await expect(page.getByText('Use scores between 0 and 5')).toHaveCount(0);
+        await expect(results(page).first()).toBeVisible();
+    });
+
+    test('rejects a fractional score rather than truncating it', async ({ page }) => {
+        // parseInt('2.5') is 2, so without a check the tabulated ballot is not
+        // the ballot that was typed.
+        await page.goto('/sandbox');
+        await expect(page.locator('#cvr')).toBeVisible();
+
+        await enter(page, '5,4,3,2,2.5');
+        await expect(page.getByText('Scores must be whole numbers')).toBeVisible();
+    });
+
+    test('reports the bad score, not the blank line after it', async ({ page }) => {
+        // A trailing newline parses as a zero-length ballot. Its "wrong length"
+        // complaint must not displace the real one.
+        await page.goto('/sandbox');
+        await expect(page.locator('#cvr')).toBeVisible();
+
+        await enter(page, '5,4,3,2,6\n');
+        await expect(page.getByText('Use scores between 0 and 5')).toBeVisible();
+    });
+
+    test('does not reject a rank above 5 under a ranked method', async ({ page }) => {
+        await page.goto('/sandbox');
+        await expect(page.locator('#cvr')).toBeVisible();
+
+        // MUI's Select takes its accessible name from the selected value, not
+        // from the label above it, so target the one combobox on the page.
+        await page.getByRole('combobox').first().click();
+        await page.getByRole('option', { name: 'Ranked Choice Voting (IRV)' }).click();
+
+        // Six candidates, so a sixth-place ranking is a legitimate mark. This is
+        // the case a flat "nothing above 5" check would get wrong.
+        const candidateField = page.locator('#candidates');
+        await candidateField.fill('A,B,C,D,E,F');
+        await candidateField.blur();
+        await enter(page, '1,2,3,4,5,6\n2,1,3,4,5,6\n3,2,1,4,5,6');
+
+        await expect(page.getByText('Use scores between 0 and')).toHaveCount(0);
+        await expect(page.getByText('Each ballot must have the same length')).toHaveCount(0);
+        // Positive assertion: the ranked ballots were counted, so the test cannot
+        // pass merely because nothing rendered.
+        await expect(results(page).first()).toBeVisible();
+    });
+});

--- a/testing/tests/sandbox.spec.ts
+++ b/testing/tests/sandbox.spec.ts
@@ -47,6 +47,16 @@ test.describe('Sandbox score validation', () => {
         await expect(page.getByText('Use scores between 0 and 5')).toBeVisible();
     });
 
+    test('rejects a fractional repeat count instead of truncating it', async ({ page }) => {
+        // parseInt('2.5') is 2, so the count was validated after it had already
+        // been rounded and 2.5:... quietly became two ballots.
+        await page.goto('/sandbox');
+        await expect(page.locator('#cvr')).toBeVisible();
+
+        await enter(page, '2.5:5,4,3,2,1');
+        await expect(page.getByText('is not a number of ballots')).toBeVisible();
+    });
+
     test('does not reject a rank above 5 under a ranked method', async ({ page }) => {
         await page.goto('/sandbox');
         await expect(page.locator('#cvr')).toBeVisible();


### PR DESCRIPTION
## Description

Closes #1117. Typing a `6` gave results and no message. The interesting part is what "silently fails" actually means here — it is not that the 6 was accepted:

`Sandbox.tsx` validated ballot *length* only → `/API/Sandbox` validates the voting method only → the tabulator's bounds test (`Tabulators/Util.ts`) **drops the whole ballot** and records it as `nOutOfBoundsVotes`, which nothing on the page shows. So the sandbox displayed a correct count of a **smaller election than the one typed in**.

Now:

> You are using incorrect score 6. Use scores between 0 and 5.

### The check is per method, because "above 5" is the wrong rule

The ranges belong to the tabulators, and half the sandbox menu disagrees with 5:

| Method | Bounds test | Range |
|---|---|---|
| STAR, STAR-PR | `Star.ts:12`, `AllocatedScore.ts:25` | 0–5 |
| Approval, Plurality | `Approval.ts:13`, `Plurality.ts:14` | **0–1** |
| Ranked Robin, IRV, STV | `RankedRobin.ts:13`, `IRV.ts:36` | rankings, bounded by `max_rankings` |

The sandbox controller passes no election settings, so for the ranked three the bound is `Infinity` — with six candidates a rank of `6` is a legitimate mark, and `Ballot.ts` deliberately does not cap ranks at the candidate count either. Those methods are left alone apart from negatives. The map is a full `Record` rather than a `Partial`, so adding a method to the menu without deciding its range is a type error instead of a silent fall-through to no validation.

### Three things the first draft got wrong

I ran an adversarial review over my own patch before opening this, and it found three:

- **It validated after `parseInt`.** `2.5` became `2`, so the ballot sent to the tabulator was not the ballot that was typed — a *different* election, silently, which is worse than the bug being fixed. The raw text is judged now: *"Scores must be whole numbers."*
- **A trailing newline masked the real error.** `5,4,3,2,6\n` parses row 2 as a zero-length ballot, and its "wrong length" complaint overwrote the score error from row 1 — the exact message this PR exists to show. Blank lines are skipped, and the first complaint is the one displayed.
- **A malformed repeat count crashes.** `x:5,4,3,2,1` reaches `Array(NaN)`, which throws out of an async `useEffect` with no handler; the previous error freezes on screen and the stale results stay. Pre-existing, one line from the code I was touching, so it gets a message of its own. Say the word if you'd rather have that as a separate PR.

### Tests

`testing/tests/sandbox.spec.ts` — the first Playwright test to visit `/sandbox` at all. Four cases: the STAR 6 (and that correcting it clears the message *and* produces results), the fractional score, the trailing newline, and a rank of 6 under IRV with six candidates being accepted.

Run against `origin/main`'s component: **the three positive tests fail, the ranked one passes.** That is the shape you want — the first three prove the fix does something, the last proves it doesn't over-reach.

### Not fixed here

Selecting Approval with score-shaped ballots still shows the previous method's results next to the new error, because the results panel keys off the fetch error rather than the validation one. Pre-existing, and a bigger change than this.

## Screenshots / Videos (frontend only)

**Desktop (1280)**

<img width="620" alt="Sandbox with ballot 5,4,3,2,6 and the error You are using incorrect score 6. Use scores between 0 and 5." src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1117_desktop_error.png">

**Mobile (390)**

<img width="300" alt="The same error on a 390px viewport" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1117_mobile_error.png">

## Related Issues

Closes #1117
