### PR TITLE
fix(results): freeze the first column of the detailed results tables

### DIFF
--- a/packages/frontend/src/components/Election/Results/components/ResultsTable.tsx
+++ b/packages/frontend/src/components/Election/Results/components/ResultsTable.tsx
@@ -17,6 +17,10 @@ const ResultsTable = ({ className='', data, winningRows=1 }: ResultsTableProps) 
         marginRight: "auto",
         maxHeight: 600,
         width: "100%",
+        // Starts the chain that gives the frozen first column an opaque
+        // background to sit on: the surrounding Paper's colour is handed down
+        // through the table to the sticky cells (see .resultTable in index.css).
+        background: "inherit",
       }}
     >
       <table className={c} style={{minWidth: '100%'}}>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -141,6 +141,31 @@ code {
   border: 1px solid black;
 }
 
+/* Keep the candidate column in view while the round columns scroll under it.
+   A sticky cell needs an opaque background or the scrolling columns show
+   through, so the background is inherited down from the surrounding Paper —
+   which is themed, unlike a hard-coded white. The per-table highlight rules
+   below are more specific than this one, so a highlighted row keeps its own
+   colour across the frozen column too. */
+.resultTable,
+.resultTable thead,
+.resultTable tbody,
+.resultTable tr {
+  background: inherit;
+}
+
+.resultTable th:first-child,
+.resultTable td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: inherit;
+}
+
+.resultTable thead th:first-child {
+  z-index: 2;
+}
+
 .starScoreTable tr:nth-child(1) > td{
   background: var(--brand-gold);
 }


### PR DESCRIPTION
## Description

Closes #1389. On an RCV election with several rounds the detailed table is wider than its container, and scrolling right takes the candidate names with it — you end up reading a wall of numbers with no idea whose row is whose.

**Before** — the same table scrolled right; the names are gone:

<img width="700" alt="RCV detailed results scrolled right: eleven round columns of numbers, no candidate names" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1389_desktop_before.png">

**After** — the first column stays:

<img width="700" alt="The same table scrolled to the same place, with the Candidate column frozen at the left" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1389_desktop_frozen.png">

**Mobile (390)** — where even a short table scrolls:

<img width="300" alt="The frozen column on a 390px viewport" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1389_mobile_frozen.png">

### Two details worth a reviewer's eye

- **The background is inherited, not hard-coded.** A sticky cell needs an opaque background or the scrolling columns show through it. The obvious `background: var(--brand-white)` would have painted every row white in the dark theme behind the `THEMES` flag, so instead the colour is handed down the chain from the surrounding `Paper`, which is themed — that is why `TableContainer` picks up `background: inherit` too; it is the first link in the chain.
- **Highlighted rows keep their colour.** `.starScoreTable`, `.starRunoffTable` and `.chooseOneTable` set backgrounds at specificity (0,2,2) against the sticky rule's (0,2,1), so they win on the frozen cell, and the winning row's gold runs behind the frozen name (visible above).

### Blast radius

It is a change to the shared `ResultsTable` styling, so it applies to all seven call sites — STAR scores and runoff, STAR-PR, Ranked Robin, Choose One, Approval, RCV. Deliberate: STAR-PR has the same many-round shape and the same problem, and on a phone even a three-column table scrolls. Tables narrow enough not to overflow get an inert sticky. It follows the pattern `MatrixViewer` already uses on the same page.

### Verification

Chromium at 1280 and 390, against a locally seeded 16-candidate, 11-round RCV election. The frozen cells report `position: sticky` with an opaque background — gold on the winning row, Paper white elsewhere. **Not checked in Firefox or Safari:** `position: sticky` on a `border-collapse: collapse` table is a combination that can drop the border at the frozen seam in some engines. It looks clean in Chromium; worth a glance in another browser before merge.

## Related Issues

Closes #1389
