### PR TITLE
Let the election Title filter match the election ID

### DIFF
--- a/packages/frontend/src/components/EnhancedTable.tsx
+++ b/packages/frontend/src/components/EnhancedTable.tsx
@@ -46,6 +46,9 @@ interface HeadCell {
   filterGroups?: {
     [key: string]: boolean
   };
+  // Extra raw fields this column's search box should also match, beyond its own
+  // value. Lets one box cover an identifier that isn't displayed in the column.
+  searchKeys?: string[];
   formatter?: (value: string, row?: string, t?: (key: string, options?: object) => string) => ReactNode;
 }
 
@@ -174,8 +177,9 @@ const headCellPool = {
     id: 'title',
     numeric: false,
     disablePadding: false,
-    label: 'Election Title',
+    label: 'Election Title or ID',
     filterType: 'search',
+    searchKeys: ['election_id'],
     formatter: (title, election) => <>{title}&nbsp;<a href={`/${election.election_id}`}>🔗</a></>
   },
   roles: {
@@ -387,7 +391,11 @@ function filterData<T>(array: readonly T[], headCells: HeadCell[], filters: any[
         let item = row[col.id];
         // if it's not a string, assume it's a ReactNode and strip away the noise
         if(typeof item !== 'string') item = row[col.id].props.children[0]
-        return item.toLowerCase().includes(filters[colInd].toLowerCase())
+        const query = filters[colInd].toLowerCase()
+        if (item.toLowerCase().includes(query)) return true
+        // also match any raw fields the column opted into (e.g. election_id)
+        return (col.searchKeys ?? []).some(key =>
+          String(row['raw']?.[key] ?? '').toLowerCase().includes(query))
       }
       if (col.filterType === 'groups') {
         return filters[colInd][row[col.id]]


### PR DESCRIPTION
## Description

The election ID is the only identifier a poll admin actually holds. It is what they pasted into the email or Slack message that invited their voters (`bettervoting.com/7mckyg`), it is in the URL bar, and it is what the API and the JSON export key on. It is also the one identifier the election tables neither display nor match — so typing it into the only search box on `/manage` returns zero rows, with no hint as to why. Recovering the match today means knowing your own title conventions, or opening rows one at a time to read the URL.

This makes the existing **Election Title** box match the election ID too, and relabels it **"Election Title or ID"** so the behaviour is discoverable rather than hidden.

### Why not an "Election ID" column?

That was the obvious fix — `election_id` is already a complete head cell (`EnhancedTable.tsx`), so adding it to a table's `headKeys` is a one-token change. But in this component **a column and a search box are the same object**: every head cell with `filterType: 'search'` renders its own `TextField` with `minWidth: 120`. Columns are therefore expensive, and the table is already wide:

| Viewport | Columns | Table width | Container | Page overflow |
|---|---|---|---|---|
| 375px (`/browse`, production) | 5 | 760px | 311px | none — `TableContainer` scrolls |
| 375px (`/manage`, 6 columns) | 6 | ~912px | 311px | none |

There is no responsive column hiding anywhere in `EnhancedTable` — no `useMediaQuery`, no breakpoint rules, just `Table sx={{ minWidth: 750 }}`. So a phone already scrolls the table horizontally, and each new column adds another ~152px to that scroll.

Reusing the box that is already there costs **zero pixels**, which the 320px screenshot below confirms: same five columns, same 760px table width, before and after.

What I deliberately avoided is making the Title box match IDs *silently*. A filter that matches a string never shown in its own column can only be learned by being told — hence the relabel.

### The change

- `HeadCell` gains an optional `searchKeys`: extra raw fields a column's search box should match beyond its own displayed value.
- The `title` head cell opts into `election_id` and is relabelled.
- `filterData` checks those raw fields after the column's own value. `row['raw']` is already the untouched row object, so nothing new is plumbed through.

Ten lines, and generic — any column can opt into extra matched fields later.

Applies to every table built from the `title` head cell: `/manage`, `/vote_history`, `/browse`, `/public_archive`, `/invitations`.

### Verification

`tsc --noEmit` on `packages/frontend` passes clean. Behaviour checked against a local stack with three seeded open elections, driving the real component through the real API:

| Typed into the box | Rows returned |
|---|---|
| `7mckyg` | the one election with that ID |
| `HB4QVV` (uppercase) | matches `hb4qvv` — case-insensitive, as the title match already was |
| `gvwr` (partial ID) | the one election containing it |
| `BV2262` (title text) | title matching still works — no regression |
| `zzz` | none |
| *(cleared)* | all three |

## Screenshots / Videos (frontend only)

Desktop (1280px) and mobile (320px), filtered by an election ID. Column count and table width are unchanged from `main` at both widths — the only visual difference is the header label.

## Related Issues

Addresses the searchability half of #1059. That issue also asks for the ID to be *visible* as its own column; this PR deliberately does not do that, for the width reasons above, so I have left it open rather than writing `fixes`. Happy to add the column instead if maintainers would rather spend the horizontal space.

Narrower than #770, which asks for ~20 additional fields and needs a design discussion.
