### PR TITLE
fix(voters): identify a duplicate row by what the row actually contains

### DIFF
--- a/packages/frontend/src/components/Election/Admin/AddElectionRoll.tsx
+++ b/packages/frontend/src/components/Election/Admin/AddElectionRoll.tsx
@@ -95,7 +95,7 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
                 return;
             }
 
-            const dialogTitle = 'You entered duplicate emails, which is not supported. Would you like us to remove duplicates?'
+            const dialogTitle = 'You entered the same voter more than once, which is not supported. Would you like us to remove duplicates?'
             const confirmed = await confirm({ title: dialogTitle, message: '', submit: 'Yes', cancel: 'No' });
             if (confirmed) {
                 const newRolls = removeDuplicates(rolls)
@@ -143,7 +143,7 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
 
 
 
-            const dialogTitle = 'You entered duplicate emails, which is not supported. Would you like us to remove duplicates?'
+            const dialogTitle = 'You entered the same voter more than once, which is not supported. Would you like us to remove duplicates?'
             const confirmed = await confirm({ title: dialogTitle, message: '', submit: 'Yes', cancel: 'No' });
             if (confirmed) {
                 const newRolls = removeDuplicates(rolls)
@@ -155,16 +155,30 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
         fileReader.readAsText(e.target.files[0]);
     }
 
+    // What identifies a row is whichever of these columns it actually carries.
+    // Keying on email alone meant that with the Email column unticked — every
+    // admin-managed voter ID election — each row keyed to the empty string, so
+    // the second row always "duplicated" the first.
+    function identityKeys(roll: RollInput): string[] {
+        const keys: string[] = [];
+        const email = (roll.email || "").trim().toLowerCase();
+        const voterId = (roll.voter_id || "").trim().toLowerCase();
+        if (email) keys.push(`email:${email}`);
+        if (voterId) keys.push(`voter_id:${voterId}`);
+        return keys;
+    }
+
     function removeDuplicates(checkRolls: RollInput[]): RollInput[] {
         const seen = new Set<string>();
         const uniqueRolls: RollInput[] = [];
 
         for (const roll of checkRolls) {
-            const email = (roll.email || "").trim().toLowerCase();
-            if (!seen.has(email)) {
-                seen.add(email);
-                uniqueRolls.push(roll);
-            }
+            const keys = identityKeys(roll);
+            // A row carrying no identifying column cannot duplicate anything,
+            // so it is kept rather than collapsed into the first such row.
+            if (keys.length > 0 && keys.some(key => seen.has(key))) continue;
+            keys.forEach(key => seen.add(key));
+            uniqueRolls.push(roll);
         }
 
         return uniqueRolls;
@@ -173,11 +187,9 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
     function duplicatesExist(pendingRolls: RollInput[]): boolean {
         const seen = new Set<string>();
         for (const roll of pendingRolls) {
-            const email = (roll.email || "").trim().toLowerCase();
-            if (seen.has(email)) return true;
-            if (!seen.has(email)) {
-                seen.add(email);
-            }
+            const keys = identityKeys(roll);
+            if (keys.some(key => seen.has(key))) return true;
+            keys.forEach(key => seen.add(key));
         }
 
         return false;

--- a/testing/tests/election-with-rolls.spec.ts
+++ b/testing/tests/election-with-rolls.spec.ts
@@ -140,6 +140,12 @@ test.describe('Add Voters', () => {
         await page.getByRole('button', {name: 'Submit'}).click(); // confirm that voter list setings can be updated after the first voter
         await page.getByLabel('Voter Data').fill(voterIds.join('\n'));
         await page.getByRole('button', {name: 'Submit'}).click();
+
+        // Every row must land. Without this the test passed while the duplicate
+        // check — which keyed on email, absent in this mode — collapsed five
+        // voter IDs into one (#1513).
+        await page.goto(`/${electionId}/admin/voters`);
+        await expect(page.getByText(`1–${voterIds.length} of ${voterIds.length}`)).toBeVisible();
     });
     test('clear voters to unlock the voter list settings', async ({ page, request }) => {
         const response = await request.post(`${API_BASE_URL}/Election/${electionId}/rolls`, {


### PR DESCRIPTION
## Description

Closes #1513. `duplicatesExist()` and `removeDuplicates()` both keyed on **email alone**. With the Email column unticked — which is every admin-managed voter ID election — `roll.email` is `undefined` on every row, so every row keyed to the empty string and the second row always "duplicated" the first.

What an admin saw: paste five voter IDs, get *"You entered duplicate emails, which is not supported"* with no email column anywhere on screen, and then

| Answer | What happens |
|---|---|
| **Yes** | `removeDuplicates` keeps one row per key — i.e. **one row** — and posts it. The other four vanish with no message, no count, no trace. |
| **No** | `onSubmit` returns without posting anything. |

So the two available answers were "add one voter" and "add none". The CSV import path makes the same two calls with the same outcome.

### The fix

A row is identified by whichever columns it actually carries — `voter_id`, `email`, or both — so two rows collide only when they share a real value. A row with no identifying column is kept rather than collapsed, since it cannot duplicate anything. The dialog no longer says "emails" when no email column is in play.

This also brings the client in line with the server: `addElectionRollController` already rejects duplicates against *existing* rolls matching on **email OR voter_id**. The client was the only place that thought identity meant email.

### The test for this was passing vacuously

`testing/tests/election-with-rolls.spec.ts` → `Add Voters › add voters` fills five voter IDs, clicks Submit, and asserted **nothing** afterwards — so it passed while the roll silently received one voter. It now asserts all five land (`1–5 of 5`, the same assertion the neighbouring test already uses). That assertion fails on `main`.

### Verification

`tsc --noEmit` clean. The E2E suite runs on this PR, which is where the new assertion gets exercised — I could not run the full Playwright suite locally (it needs the auth-setup project against a logged-in Keycloak user). If CI disagrees with me, I'll fix it here.

## Related Issues

Closes #1513
