### PR TITLE
fix(results): make the majority marker say what it is half of

### DIFF
--- a/packages/frontend/src/components/Election/Results/IRV/winner.tsx
+++ b/packages/frontend/src/components/Election/Results/IRV/winner.tsx
@@ -39,6 +39,13 @@ export function IRVWinnerView ( {win, context}:{
     }
   ];
 
+  // Half of the votes still active in the final round — which is what the
+  // marker is drawn at, while the bar labels are shares of every ballot in the
+  // chart including the exhausted ones. The legend names which it is half of.
+  const activeVotes = runoffData
+    .slice(0, -1)
+    .reduce((sum, d) => sum + (d.votes ?? 0), 0);
+
   return <WidgetContainer>
     <Widget title={t('results.rcv.first_choice_title')}>
       <ResultsBarChart data={firstRoundData} percentage majorityOffset/>
@@ -46,7 +53,7 @@ export function IRVWinnerView ( {win, context}:{
     <Widget title={t('results.rcv.final_round_title')}>
       < ResultsBarChart
         data={runoffData} runoff stars={1} percentage
-        majorityLegend={t('results.rcv.runoff_majority')}
+        majorityLegend={t('results.rcv.runoff_majority', {n: activeVotes})}
       />
     </Widget>
   </WidgetContainer>

--- a/packages/frontend/src/components/Election/Results/STAR/STARResultSummaryWidget.tsx
+++ b/packages/frontend/src/components/Election/Results/STAR/STARResultSummaryWidget.tsx
@@ -55,6 +55,14 @@ const STARResultSummaryWidget = ({ results, roundIndex, t }: {results: starResul
         ? (noPreferenceVotes / results.summaryData.nTallyVotes * 100).toFixed(1)
         : '0.0';
 
+    // The marker is half of the voters who expressed a preference, while the bar
+    // labels are shares of everyone who voted — so the legend has to say which
+    // number it is half of, or a 33% bar sits to the right of a "majority" line.
+    const preferenceVotes = pieData[0].votes + pieData[1].votes;
+    // With enough voters scoring the finalists equally, neither finalist can be
+    // preferred by half the electorate at all. Worth saying out loud.
+    const noOverallMajorityPossible = Math.max(pieData[0].votes, pieData[1].votes) <= results.summaryData.nTallyVotes / 2;
+
     const runoffData = [...pieData]
     runoffData.push({
       name: t('results.star.equal_preferences'),
@@ -84,7 +92,12 @@ const STARResultSummaryWidget = ({ results, roundIndex, t }: {results: starResul
                     </>
                 :
                 <>
-                    <ResultsBarChart data={runoffData} stars={1} runoff percentage majorityLegend={t('results.star.runoff_majority')} />
+                    <ResultsBarChart data={runoffData} stars={1} runoff percentage majorityLegend={t('results.star.runoff_majority', {n: preferenceVotes})} />
+                    {noOverallMajorityPossible &&
+                        <Typography variant="body2" sx={{ fontStyle: 'italic', textAlign: 'center', mt: 1 }}>
+                            {t('results.star.runoff_no_overall_majority', {equal_votes: noPreferenceVotes, total_votes: results.summaryData.nTallyVotes})}
+                        </Typography>
+                    }
                     <Box sx={{ height: 50 }}/> {/*HACK to get the bar chart to be the same height as the pie chart*/}
                 </>
                 }

--- a/packages/frontend/src/components/Election/Results/components/ResultsBarChart.tsx
+++ b/packages/frontend/src/components/Election/Results/components/ResultsBarChart.tsx
@@ -80,20 +80,27 @@ const [rawNumbers, setRawNumbers] = useState(false);
   }
 
   // Add majority
+  // NOTE: majorityOffset on its own draws no line — the <Line> below keys off
+  // majorityLegend, so with no legend there is nothing to render. It runs this
+  // block purely for the spacer row and colour rotation.
   if (majorityLegend || majorityOffset) {
     const sum = data.reduce((prev, d, i) => {
       if(i == data.length-1) return prev; // don't include exhausted or equal support votes in the denominator
       return prev + d[xKey];
     }, 0);
     const m = sum / 2;
-    data = data.map((d, i) => {
-      const s = { ...d };
-      s[majorityLegend] = i < 2 ? m : null;
-      return s;
-    });
-    const s = { name: "" };
-    s[majorityLegend] = m;
-    data.unshift(s);
+    if (majorityLegend) {
+      // The marker spans the whole plot. Setting it on the first two rows only
+      // stopped the dashed line short of the exhausted / equal-support bar,
+      // which reads as "the threshold doesn't apply to this row" while that bar
+      // visibly crosses it.
+      data = data.map((d) => ({ ...d, [majorityLegend]: m }));
+      const s = { name: "" };
+      s[majorityLegend] = m;
+      data.unshift(s);
+    } else {
+      data.unshift({ name: "" });
+    }
     colors.unshift(colors.pop());
   }
 

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -283,7 +283,7 @@ results:
     first_choice_title: First Choice Preferences
     final_round_title: Final Runoff
     table_title: Ranked Choice Tabulation Rounds
-    runoff_majority: majority threshold (½ of remaining active votes)
+    runoff_majority: 'majority threshold — ½ of the {{n}} votes still active'
     exhausted: Exhausted
     tabulation_candidate_column: '{{capital_candidate}}'
     round_column: Round {{n}}
@@ -301,8 +301,12 @@ results:
     runoff_description:
       - Each vote goes to the voter's preferred finalist.
       - Finalist with most votes wins.
-    runoff_majority: majority threshold (½ of voters with preference)
+    runoff_majority: 'majority threshold — ½ of the {{n}} voters with a preference'
     runoff_no_preference_footnote: "{{percentage}}% of voters expressed no preference between the two finalists."
+    runoff_no_overall_majority: >
+      With {{equal_votes}} of {{total_votes}} voters scoring the two finalists equally, neither
+      finalist could be preferred by half of everyone who voted. The threshold above is half of
+      the voters who did express a preference.
     score_table_title: Scores Table
     score_table_columns:
       - '{{capital_candidate}}'


### PR DESCRIPTION
## Description

Closes #1471 — **option 2**, as you preferred: leave the labels alone and make the legend state its own basis.

The labels divide by every bar; the marker divides by every bar except the last. Both are defensible, neither is comparable to the other, and the chart puts them side by side.

| | before | after |
|---|---|---|
| STAR | `majority threshold (½ of voters with preference)` | `majority threshold — ½ of the 5 voters with a preference` |
| IRV | `majority threshold (½ of remaining active votes)` | `majority threshold — ½ of the 12 votes still active` |

Plus the two points from your follow-up comment:

- **The dashed line stopped after two bars** (`s[majorityLegend] = i < 2 ? m : null`), so it stopped short of the Equal Support / Exhausted bar — reading as "the threshold doesn't apply to this row" while that bar visibly crossed it. It now spans the plot.
- **When enough voters score the finalists equally, no finalist *can* reach half the electorate.** That is arguably the thing the chart most needs to say and the one thing it couldn't. The STAR runoff now says it in one line, and only when it's true.

Also documents that `majorityOffset` alone draws no line — it runs the block for the spacer row and colour rotation, which is not what the name suggests — and stops it writing to an `"undefined"` key on the way past.

### Screenshots

**Your nine-ballot case** (3 prefer Ada, 2 prefer Ben, 4 equal): legend reads 5, the line spans all three bars, and the note explains why 44% belongs to nobody.

<img width="620" alt="Runoff chart: Ada 33%, Ben 22%, Equal Support 44%, dashed line spanning all three bars, legend reading half of the 5 voters with a preference, and a note that neither finalist could be preferred by half of everyone who voted" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1471_desktop_runoff.png">

**Mobile (390)**

<img width="300" alt="The same chart on a 390px viewport" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1471_mobile_runoff.png">

**An 8-voter race with 1 Equal Support** — legend reads 7, and the note correctly stays away:

<img width="620" alt="Runoff chart with the legend reading half of the 7 voters with a preference and no note" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1471_nonote_runoff.png">

### Note on overlap

This touches `en.yaml`'s `results.star.runoff_majority` and `STARResultSummaryWidget.tsx`, both of which #1515 also touches. Whichever lands first, I'll rebase the other — happy to fold them together if you'd rather review one.

The three non-English locales still carry the pre-existing wording of these legends (they were never updated when the English one was), so they fall back to their own text without the count. Left alone rather than machine-translating.

## Related Issues

Closes #1471
