### PR TITLE
docs: add a help page for why the highest score doesn't always win

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -9,6 +9,7 @@ parent: BetterVoting Documentation
 
 - [How do you run races with "None of the Above"?](#how-do-you-run-races-with-none-of-the-above)
 - [What does "write-in scores not counted" mean?](#write-in-scores-not-counted)
+- [Why is the top scoring candidate different from the winner?](#top-scorer-vs-winner)
 
 ## How do you run races with "None of the Above"?
 
@@ -27,3 +28,20 @@ A “score” in this context is one voter’s rating of one candidate. For exam
 - **The admin chose not to approve a write-in.** For example, joke entries or candidates who are ineligible may be intentionally excluded.
 
 If you are an election admin, you can review and approve write-in candidates from the admin panel by clicking the pencil icon next to any race with write-ins enabled.
+
+## Why is the top scoring candidate different from the winner?
+{: #top-scorer-vs-winner}
+
+STAR Voting is counted in two rounds, and they measure two different things. The scoring round measures **how much** support each candidate has. The runoff round measures **how many** voters prefer one finalist to the other. Usually the same candidate leads both. When they differ, the runoff decides it — and that is by design, not a quirk of the count.
+
+The reason the two rounds can disagree is that the runoff throws away the size of a preference and keeps only its direction:
+
+| A ballot scoring… | In the scoring round | In the runoff |
+|---|---|---|
+| Ada 5, Ben 4 | a 1-star edge for Ada — small | one full vote for Ada |
+| Ada 5, Ben 0 | a 5-star edge for Ada — large | one full vote for Ada |
+| Ada 3, Ben 3 | no edge either way | no vote either way — [equal support](https://www.starvoting.org/equal_preference) |
+
+So a candidate can lead the scoring round on a handful of enthusiastic ballots while more voters — counting one voter, one vote — prefer the other finalist. The runoff winner is the one **more voters preferred**, which is what "majority" means, and it is the reason a voter can score their honest favourite top without worrying that doing so throws the election.
+
+The runoff is also why scoring everyone at the extremes is not required to be heard: your full vote goes to whichever finalist you scored higher, however small the gap you gave them.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -32,16 +32,8 @@ If you are an election admin, you can review and approve write-in candidates fro
 ## Why is the top scoring candidate different from the winner?
 {: #top-scorer-vs-winner}
 
-STAR Voting is counted in two rounds, and they measure two different things. The scoring round measures **how much** support each candidate has. The runoff round measures **how many** voters prefer one finalist to the other. Usually the same candidate leads both. When they differ, the runoff decides it — and that is by design, not a quirk of the count.
+STAR Voting is counted in two rounds. The **Scoring Round** adds up the stars and picks the two finalists — it measures *how much* support each candidate has. The **Automatic Runoff** then asks *how many* voters prefer one finalist to the other, and your ballot counts as one vote for whichever of the two you scored higher.
 
-The reason the two rounds can disagree is that the runoff throws away the size of a preference and keeps only its direction:
+So a candidate can collect the most stars and still lose to the finalist more voters preferred. That is the runoff doing its job, not a counting error.
 
-| A ballot scoring… | In the scoring round | In the runoff |
-|---|---|---|
-| Ada 5, Ben 4 | a 1-star edge for Ada — small | one full vote for Ada |
-| Ada 5, Ben 0 | a 5-star edge for Ada — large | one full vote for Ada |
-| Ada 3, Ben 3 | no edge either way | no vote either way — [equal support](https://www.starvoting.org/equal_preference) |
-
-So a candidate can lead the scoring round on a handful of enthusiastic ballots while more voters — counting one voter, one vote — prefer the other finalist. The runoff winner is the one **more voters preferred**, which is what "majority" means, and it is the reason a voter can score their honest favourite top without worrying that doing so throws the election.
-
-The runoff is also why scoring everyone at the extremes is not required to be heard: your full vote goes to whichever finalist you scored higher, however small the gap you gave them.
+[Why the highest score doesn't always win](top_score_vs_winner.md) walks through a small election where this happens, and explains what it means for voters and for whoever is running the election.

--- a/docs/help/top_score_vs_winner.md
+++ b/docs/help/top_score_vs_winner.md
@@ -1,0 +1,97 @@
+---
+layout: default
+title: Why the highest score doesn't always win
+nav_order: 4
+parent: BetterVoting Documentation
+---
+
+{:toc}
+
+# Why the highest score doesn't always win
+
+One candidate collected the most stars, and someone else is marked the winner. Nothing has gone wrong, and nothing needs to be recounted.
+
+**The winner is the candidate more voters preferred.** Collecting the most stars is how you reach the final two — it is not how you win. Most of the time the same candidate does both, and the results page looks unremarkable. When they come apart, it is called a **Runoff Reversal**, and the rest of this page is what happened.
+
+## The two rounds ask different questions
+
+Your results page shows both rounds, in order.
+
+**The Scoring Round** adds up the stars. It asks **how much** support each candidate has. The two candidates with the most stars become the **finalists**. Everyone else is out.
+
+**The Automatic Runoff** compares those two finalists head to head. It asks **how many** voters prefer one to the other. Your ballot counts as one full vote for whichever finalist you scored higher — and that is all it counts as. A five-star gap and a one-star gap are the same single vote here.
+
+That difference is the whole answer. The Scoring Round is sensitive to **how big** a gap you gave. The runoff only asks **which side** of the gap you are on.
+
+## A small election where they come apart
+
+Nine people vote on three candidates. Each row is a group of voters who filled the ballot in the same way.
+
+| Voters | Ada | Ben | Cleo |
+|:--|:--:|:--:|:--:|
+| 5 voters | ★★★★ (4) | ★ (1) | ★★ (2) |
+| 4 voters | ★ (1) | ★★★★★ (5) | (0) |
+
+**Scoring Round — how much support?**
+
+| Candidate | Stars |
+|:--|:--:|
+| **Ben** | **25** |
+| **Ada** | **24** |
+| Cleo | 10 |
+
+Ben finishes one star ahead. Ben and Ada are the finalists.
+
+**Automatic Runoff — how many voters prefer each finalist?**
+
+| Finalist | Votes |
+|:--|:--:|
+| **Ada** | **5** |
+| Ben | 4 |
+
+Ada wins, with five of the nine votes cast.
+
+Look at where Ben's 25 stars came from: four voters who gave him everything they had. That is real support, and it is why he made the final two. But the other five voters preferred Ada — not by much, four stars to one, yet a preference is a preference. In the runoff, those five voters count as five, and Ben's four count as four.
+
+Ben was scored highest. Ada was **preferred by more people**. STAR gives it to Ada.
+
+## Is this a flaw?
+
+It is not a malfunction, and no tie was broken behind the scenes — the result follows from the ballots, and you would get the same answer counting them by hand.
+
+It can still feel jarring, and that reaction is fair enough: you are looking at a big number next to a name that did not win.
+
+Here is the reason it works this way. If stars alone decided it, four voters giving one candidate maximum scores could outweigh five voters who wanted someone else — and the way to win would be to never give an honest 4, only 5s and 0s. The runoff removes both problems at once, because the deciding round counts *people*, one each. That is what makes the Scoring Round safe to answer honestly.
+
+{: .note }
+> A useful way to say it out loud: **leading the Scoring Round makes you a finalist, not the winner. The winner is whichever finalist more voters preferred.**
+
+## "Equal Support" — why the runoff numbers can be smaller
+
+The runoff may show a third row, **Equal Support**, with a matching note under the chart.
+
+That row is the voters who gave both finalists the *same* score — two 5s, two 3s, two 0s, or neither one marked. Whether that means "both of these are fine" or "neither of these is for me", the ballot does not pick between them, so it is counted as Equal Support rather than as a vote for either.
+
+Nothing has been thrown away. Those ballots counted in full in the Scoring Round, they helped decide which two candidates became the finalists, and they are reported on the page — which is why the numbers reconcile. It does mean the two finalists' votes can add up to less than the number of voters, and that the winner is the finalist preferred by more of the voters **who expressed a preference**.
+
+## What this means for you
+
+**"So my 5s counted for less?"** No. Your ballot counted in full in both rounds. In the example above, the four voters who gave Ben five stars each got exactly what everyone else got in the runoff: one vote. They were on the four-vote side of a 5–4 count.
+
+**If you are voting:** score every candidate honestly, using the whole scale. Give your favorite 5 and your least favorite 0, then use the middle scores to say what you actually think of everyone else. You never need to inflate a score to protect a candidate — however small a gap you leave between two of them, if both reach the runoff your ballot counts as a full vote for the one you scored higher.
+
+**If you are running the election:** explain this before anyone asks. The sentence that usually lands is *"Ben got the most stars, but more of us preferred Ada."* Your results page shows both rounds, so you can walk the group through exactly where each number came from — or send them this page.
+
+## Related pages
+
+- [Hand Count](hand_count.md) — counting a STAR election by hand, round by round. The clearest way to see where each number comes from.
+- [Ties](ties.md) — what happens when either round ends level
+- [Frequently Asked Questions](faq.md)
+
+## If you want to go deeper
+
+You do not need any of this to read your results — the two rounds above are the whole story.
+
+- [How STAR Voting works](https://www.starvoting.org/star) — an introduction to the method
+- [Equal preferences](https://www.starvoting.org/equal_preference) — more on scoring two candidates the same
+- Both are published by the [Equal Vote Coalition](https://www.equal.vote/), the organization behind STAR Voting.

--- a/packages/frontend/src/components/Election/Results/STAR/STARExtraContext.tsx
+++ b/packages/frontend/src/components/Election/Results/STAR/STARExtraContext.tsx
@@ -1,10 +1,12 @@
 import { starResults } from "@equal-vote/star-vote-shared/domain_model/ITabulators";
 import { Paper, Typography } from "@mui/material";
-import { useTranslation } from "react-i18next";
+import { useSubstitutedTranslation } from "~/components/util";
 
 
 const STARExtraContext = ({ results, roundIndex }: {results: starResults, roundIndex: number}) => {
-    const { t } = useTranslation();
+    // useSubstitutedTranslation, not the bare react-i18next hook: it is what
+    // turns [text](url) in the locale file into an actual link.
+    const { t } = useSubstitutedTranslation();
     const width = 'auto';
     const winner = results.roundResults[roundIndex].winners[0];
     const runnerUp = results.roundResults[roundIndex].runner_up[0];

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -323,11 +323,13 @@ results:
     equal_preferences_title: Distribution of Equal Support
     equal_preferences: Equal Support
     score_higher_than_runoff_title: Why is the top scoring candidate different from the winner?
-    score_higher_than_runoff_text: |
-      The top-scoring candidate often matches the runoff winner, but not always.
-      The scoring round captures the overall support for each of the candidates,
-      but ultimately the winning candidate is the finalist preferred by the most voters.
-      This ensures equality of the vote, and also encourages honest voting.
+    score_higher_than_runoff_text: >
+      The scoring round measures how much support each candidate has; the runoff
+      measures how many voters prefer one finalist to the other. Usually the same
+      candidate leads both, and when they differ the runoff decides it: the winner
+      is the finalist more voters preferred. That is what keeps one voter to one
+      vote, and what makes it safe to score your honest favourite top.
+      [Why the two rounds can disagree](https://docs.bettervoting.com/help/faq.html#top-scorer-vs-winner)
 
   star_pr:
     chart_title: Round {{n}} Results

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -329,7 +329,7 @@ results:
       candidate leads both, and when they differ the runoff decides it: the winner
       is the finalist more voters preferred. That is what keeps one voter to one
       vote, and what makes it safe to score your honest favourite top.
-      [Why the two rounds can disagree](https://docs.bettervoting.com/help/faq.html#top-scorer-vs-winner)
+      [Why the two rounds can disagree](https://docs.bettervoting.com/help/top_score_vs_winner.html)
 
   star_pr:
     chart_title: Round {{n}} Results


### PR DESCRIPTION
## Description

Closes #1159 — a dedicated help page for the question the app pops up on a results page, plus the link from the app to reach it.

@jacksonloper's comment set the shape: *"make it terser and to the point"* and *"add a link to a place where the issue is explained more fully."* Only the second half was still outstanding — the popover text had already been shortened at some point. What was missing was somewhere for it to point.

### What's here

- **`docs/help/top_score_vs_winner.md`** — *"Why the highest score doesn't always win"*. Written for the person who has just looked at a results page and thinks something is broken: what each round measures, a nine-voter election worked through end to end, why the runoff has the final say, what Equal Support is, and one paragraph each for "you are voting" and "you are running this election".
- **The FAQ entry** becomes a three-line answer that hands off to the page, rather than a second copy of the explanation.
- **The in-app text** (`results.star.score_higher_than_runoff_text`) is two sentences ending in a link to the new page.
- **`STARExtraContext`** switches from the bare `react-i18next` hook to `useSubstitutedTranslation`, which is what turns `[text](url)` in the locale file into an actual anchor. Without it the markdown prints literally — worth knowing before adding a link to any other string rendered by a component using the plain hook.

### On the writing

This is a hard page to get right, so it was drafted against the STAR education material and then reviewed against it, and several things changed as a result:

- **"Equal" is a trap word here.** Saying a 5-vs-0 ballot counts "equally" in the runoff collides with **Equal Support**, which means the opposite — a ballot that scored both finalists the *same*. The page says a five-star gap and a one-star gap are *the same single vote*, and reserves "Equal Support" for its real meaning.
- **Nothing is discarded.** An Equal Support ballot counted in full in the scoring round and helped choose the finalists; it is reported, not dropped. The page says so, because "your vote didn't count" is the reading to head off.
- **It doesn't oversell.** A reversal is a real trade-off, not an obviously-correct outcome, and the page says the reaction is fair before explaining why STAR resolves it the way it does.
- **The theory stays out.** There is a short, clearly-optional "if you want to go deeper" block pointing at starvoting.org and equal.vote. Deeper material belongs there, not duplicated into the help site where it would drift.

### Verification

Built locally with the `github-pages` gem (Jekyll 3.9, same as Pages). The page appears in the sidebar under **BetterVoting Documentation** — the `parent:` matches, which is the failure that is invisible in the GitHub editor — all `.md` links rewrite to `.html`, the callout renders, and the FAQ's link resolves. Screenshots below are from that build. The example's arithmetic was computed independently before it was written down.

**One thing for maintainers to note:** this adds a **ninth** hardcoded app → docs URL (`en.yaml` now points at `/help/top_score_vs_winner.html`), so renaming or moving this page later breaks the results page. Redirects do not currently work on this site — `_config.yml` has no `plugins:` key, so `redirect_from:` emits nothing.

## Screenshots / Videos (frontend only)

**The page** (desktop 1280 · rendered from the local Pages build)

<img width="760" alt="The help page rendered on docs.bettervoting.com, showing both rounds, the worked example tables, and the Equal Support section" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1159_page_desktop.png">

**Mobile (390)**

<img width="300" alt="The same page on a 390px viewport" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1159_page_mobile.png">

**In the app** — the panel that links to it, on an election where the runoff reverses the scoring round

<img width="620" alt="The results panel explaining why the top scorer differs from the winner, ending in a link" src="https://raw.githubusercontent.com/masiarek/star-server/pr-screenshots/1159_desktop_explainer.png">

## Related Issues

Closes #1159
