### PR TITLE
fix(manage): read the whole text of a formatted cell when filtering

### DIFF
--- a/packages/frontend/src/components/EnhancedTable.tsx
+++ b/packages/frontend/src/components/EnhancedTable.tsx
@@ -376,6 +376,16 @@ function stableSort<T>(array: readonly T[], comparator: (a: T, b: T) => number) 
 
 // type filterTypes = 'search' | 'groups' | null
 
+// The visible text of a formatted cell, whatever shape the formatter returned.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const nodeText = (node: any): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') return '';
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(nodeText).join('');
+  return nodeText(node.props?.children);
+};
+
 function filterData<T>(array: readonly T[], headCells: HeadCell[], filters: any[]) {
   // when tweaking the headKeys the filters and headCells can sometimes be temporarily mismatched
   if (headCells.length != filters.length) return array;
@@ -384,9 +394,11 @@ function filterData<T>(array: readonly T[], headCells: HeadCell[], filters: any[
       if (!col.filterType) return true
       if (col.filterType === 'search') {
         if (filters[colInd] == '') return true
-        let item = row[col.id];
-        // if it's not a string, assume it's a ReactNode and strip away the noise
-        if(typeof item !== 'string') item = row[col.id].props.children[0]
+        // A formatted cell is a ReactNode, so read the text out of it. Taking
+        // .props.children[0] only worked for a formatter whose children are an
+        // array: where the single child is the string itself, [0] is its first
+        // *character*, and the column's search box then matches nothing but "x".
+        const item = nodeText(row[col.id]);
         return item.toLowerCase().includes(filters[colInd].toLowerCase())
       }
       if (col.filterType === 'groups') {


### PR DESCRIPTION
## Description

Refs #1059 — not the feature, the thing standing in front of it.

A column's search box compares the query against the cell's text, and for a formatted cell it got that text with `row[col.id].props.children[0]`. That works only when the formatter's children are an **array**. When the single child is the string itself — which is exactly what the `election_id` formatter returns, `<Link>{id}</Link>` — `[0]` is the first **character**, so the box matches nothing but `"z"`.

Nobody has hit this because `election_id` is defined in the column pool and used by **no table**. It is also precisely the column #1059 asks for, so whoever adds it first would ship a search box that finds nothing.

`nodeText()` walks whatever the formatter returned — string, number, array, element — and joins the text. Checked against the two real formatters:

| Column | Formatter | old | new |
|---|---|---|---|
| `election_id` | `<Link>{id}</Link>` | `"z"` | `"zz3ab7"` |
| `title` | `<>{title}&nbsp;<a>🔗</a></>` | `"My Election"` | `"My Election 🔗"` |

so the title column keeps matching what it matched before, and the ID column starts matching at all.

### Why this and not the column

The issue offers two ways to surface the ID. My read, having measured the table:

- **A new `El_ID` column is one token** — `election_id` is already a complete head cell, so it is `headKeys={['election_id', 'title', ...]}`. But in `EnhancedTable` a column *is* a search box (every `filterType: 'search'` head cell renders its own `TextField` at `minWidth: 120`) and there is no responsive column hiding anywhere in the component. `/manage` is already ~912px of table at six columns.
- **Concatenating the ID into the Description field** I'd argue against: the description is user-authored content, mixing a system identifier into it breaks that column's own search, and the ID ends up buried in prose where it can't be sorted or copied cleanly.

Either way both options depend on this fix. I've deliberately not added the column here — that's a width decision for maintainers, and #1518 already touches the same `headKeys` line.

### Overlap

Touches the same filter block as #1524 (which adds `searchKeys` so the Title box also matches the ID). The two are complementary — that one lets one box cover the ID, this one makes the ID's *own* box work — but they will want a small rebase depending on merge order. Happy to do it.

## Related Issues

Refs #1059
