### PR TITLE
fix(about): link Jackson Loper to his own GitHub profile

### DIFF
--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -976,7 +976,7 @@ about:
     - 'Evans Tucker [@evanstucker](https://github.com/evanstucker-hates-2fa): BetterVoting Infrastructure Lead'
     - 'Adam Masiarek [@masiarek](https://github.com/masiarek): BetterVoting Testing & Admin Lead'
     - 'Jon Blauvelt [@JonBlauvelt](https://github.com/JonBlauvelt): BetterVoting Dev Lead'
-    - 'Jackson Loper [@JonBlauvelt](https://github.com/JonBlauvelt): BetterVoting Dev Lead'
+    - 'Jackson Loper [@jacksonloper](https://github.com/jacksonloper): BetterVoting Dev Lead'
   contributors_title: All Contributors
   # The image Id can be found by copying the image address of their github profile
   contributors:


### PR DESCRIPTION
## Description

Closes part of #1127 — the one bit of it that is wrong in production right now.

The **Our Leads** list gives Jackson Loper the handle and profile URL of Jon Blauvelt, the entry directly above him:

```yaml
- 'Jon Blauvelt [@JonBlauvelt](https://github.com/JonBlauvelt): BetterVoting Dev Lead'
- 'Jackson Loper [@JonBlauvelt](https://github.com/JonBlauvelt): BetterVoting Dev Lead'
```

The typo is in the content block the issue asked to be applied, so it was copied faithfully out of the issue body and is live on [bettervoting.com/about](https://bettervoting.com/about). His handle is `jacksonloper` — which is how he is already listed further down in the **All Contributors** block, and how he appears as the author of #1491 and #1477.

### What is still open on #1127

The leads *content* has been applied since the issue was filed, so what remains is the presentation and the data I do not have:

- the card layout with profile pictures (the hackforla-style rectangles)
- @ArendPeter's follow-up: link names to **Slack profiles** rather than GitHub — I don't have those URLs
- adding the recently active volunteers to All Contributors

Happy to do any of them with the missing details.

## Related Issues

Refs #1127
