### PR TITLE
fix(feedback): don't let a missing widget turn Feedback into a no-op

### DIFF
--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -311,14 +311,29 @@ export const truncName = (name, maxSize) => {
   return name.slice(0, maxSize - 3).concat("...");
 };
 
+// Fallback when the feedback widget isn't there to click.
+export const FEEDBACK_EMAIL = 'elections@equal.vote';
+
 export const openFeedback = () => {
-  // simulate clicking the feedback button
-  const launcherFrame = document.getElementById("launcher-frame");
-  const button =
-    (launcherFrame as HTMLIFrameElement).contentWindow.document.getElementsByClassName(
-      "launcher-button"
-    )[0];
-  (button as HTMLButtonElement).click();
+  // Simulate clicking the widget's own button. Every step here can fail on a
+  // browser that hasn't loaded the widget — the iframe may be absent, blocked,
+  // or still loading, and reading its document can throw outright. Unguarded,
+  // any of those turned the Feedback menu item into a no-op with nothing but a
+  // console error (#1080, reported on iOS).
+  try {
+    const launcherFrame = document.getElementById("launcher-frame") as HTMLIFrameElement | null;
+    const button = launcherFrame?.contentWindow?.document
+      ?.getElementsByClassName("launcher-button")[0] as HTMLButtonElement | undefined;
+    if (button) {
+      button.click();
+      return;
+    }
+  } catch (err) {
+    console.warn('Feedback widget could not be opened', err);
+  }
+
+  // Rather than appear broken, hand the user a way to reach us.
+  window.location.href = `mailto:${FEEDBACK_EMAIL}?subject=${encodeURIComponent('BetterVoting feedback')}`;
 };
 
 export function scrollToElement(e, opts: { behavior?: ScrollBehavior; delay?: number; cancelOnUserInput?: boolean } = {}) {


### PR DESCRIPTION
## Description

Refs #1080. `openFeedback()` reaches into the feedback widget's iframe and clicks the button inside it, with no guard at any step:

```ts
const launcherFrame = document.getElementById("launcher-frame");
const button = (launcherFrame as HTMLIFrameElement).contentWindow.document
    .getElementsByClassName("launcher-button")[0];
(button as HTMLButtonElement).click();
```

If the widget has not loaded — blocked, slow, or stopped by a browser's tracking protection, which is the usual story on iOS — `launcherFrame` is `null` and this throws. The **Feedback** menu item then does nothing at all, and the only trace is a console error no user will see. Reading the iframe's document can throw outright too.

Each step is now optional-chained inside a `try`, and when the widget cannot be reached the click falls back to a `mailto:` rather than failing silently.

### What this is and isn't

**I could not reproduce the iPhone case** — no device. This fixes the failure mode the code makes possible, which matches the symptom in the video (tapping Feedback does nothing). If the widget *is* loading on that phone and the button *is* being clicked, the cause is elsewhere and this change only removes a way for it to fail quietly.

Worth a second opinion on the fallback address: I used `elections@equal.vote`, which is the contact address already used elsewhere in `en.yaml`. If there is a better destination for feedback specifically, say the word.

## Related Issues

Refs #1080
