### PR TITLE
fix(emails): count the voters the blast will actually go to

### DIFF
--- a/packages/frontend/src/components/Election/Admin/SendEmailDialog.tsx
+++ b/packages/frontend/src/components/Election/Admin/SendEmailDialog.tsx
@@ -72,12 +72,17 @@ const SendEmailDialog = ({open, onClose, onSubmit, targetedEmail=undefined, elec
         }))
     }
 
+    // The backend re-queries the roll when it sends, so this count has to be of
+    // the same thing it will find. The roll is refetched when the dialog is
+    // opened; before that fix the button could offer to send to voters who had
+    // already voted since the page was loaded (#1287).
     const getVoterCount = () => {
         if(!electionRoll) return 0;
         if(audience == 'single') return 1;
         if(audience == 'all') return electionRoll.length;
         if(audience == 'has_voted') return electionRoll.filter(roll => roll.submitted).length
         if(audience == 'has_not_voted') return electionRoll.filter(roll => !roll.submitted).length
+        return 0;
     }
 
     const warning: string = (() => {
@@ -174,7 +179,7 @@ const SendEmailDialog = ({open, onClose, onSubmit, targetedEmail=undefined, elec
                 </Alert>}
                 <Box sx={{ display: "flex", flexDirection: "row-reverse", gap: 2 }}>
                     <PrimaryButton
-                        disabled={!templateChosen}
+                        disabled={!templateChosen || getVoterCount() === 0}
                         onClick={() => {
                             setTemplateChosen(false)
                             onSubmit({

--- a/packages/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
+++ b/packages/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
@@ -167,7 +167,7 @@ const ViewElectionRolls = () => {
                             </PermissionHandler>
                         }
                         {usesEmail &&
-                            <SecondaryButton onClick={() => setDialogOpen(true)} sx={{ml: 2}}>Draft Email Blast</SecondaryButton>
+                            <SecondaryButton onClick={() => { fetchRolls(); setDialogOpen(true); }} sx={{ml: 2}}>Draft Email Blast</SecondaryButton>
                         }
                         {canClearRolls &&
                             <PermissionHandler permissions={permissions} requiredPermission={'canAddToElectionRoll'}>


### PR DESCRIPTION
## Description

Closes #1287 — *"The button said 'Send 3 emails' even though 2 of the 3 voters had already voted … only 1 email was sent (which is correct)"*.

Both sides apply the same filter. They apply it to **different snapshots**.

| | Where the number comes from |
|---|---|
| The button | `electionRoll`, an array fetched once when the Voters page mounts — `useGetRolls` in a `useEffect` with an empty dependency list, refetched only after editing a voter or clearing the list |
| The send | `sendEmailController` re-queries the roll at send time and filters again |

So any ballot cast between page load and pressing the button makes the number wrong. That is exactly the reported scenario, and it needs no SendGrid access to see — it is two snapshots of one table.

### Two changes

- **Opening "Draft Email Blast" refetches the roll**, so the count is of the same rows the backend is about to select.
- **The button is disabled at zero.** Previously a stale positive count could be pressed against an empty target, and the backend answered with a 400 — *"All voters have voted"* — an error for a situation the UI should not have offered.

The reporter suggested dropping the number instead; @ArendPeter's reply says the count is worth keeping *"to give myself confidence that I'm filtering it properly"*. This keeps it and makes it true.

### Not in scope

A roll whose email is blank or undeliverable is still counted and still queued. That is a delivery concern rather than a count mismatch, and the issue does not ask about it.

There is no test coverage of recipient selection at all — no backend test touches `sendEmails`, and no Playwright spec opens this dialog. Worth adding, but it needs a fixture with a partly-voted roll, which is more than this fix.

## Related Issues

Closes #1287
