### PR TITLE
feat(emails): tell admins what to do when an email doesn't arrive

### DIFF
--- a/packages/frontend/src/components/Election/Admin/SendEmailDialog.tsx
+++ b/packages/frontend/src/components/Election/Admin/SendEmailDialog.tsx
@@ -172,6 +172,9 @@ const SendEmailDialog = ({open, onClose, onSubmit, targetedEmail=undefined, elec
                     }}>
                     <Typography>{warning}</Typography>
                 </Alert>}
+                <Typography sx={{ color: '#808080', fontSize: '0.9rem', mx: 1, mb: 1 }}>
+                    {t('emails.delivery_note')}
+                </Typography>
                 <Box sx={{ display: "flex", flexDirection: "row-reverse", gap: 2 }}>
                     <PrimaryButton
                         disabled={!templateChosen}

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -1275,6 +1275,9 @@ emails:
     Voters will not be able to cast ballots until the elction has opened.
   post_end_warning: >
     This election is already closed on {{datetime, datetime}} and voters will not be able to cast ballots.
+  delivery_note: >
+    Not seeing emails in your inbox? First make sure to check spam. If that doesn't work,
+    please use the feedback widget in the corner and a team member will work with you promptly.
   invite:
     subject: Invitation to vote in {{title}}
     body: |


### PR DESCRIPTION
## Description

Closes #1270 — a line above the Send button giving admins the first two steps when voters report a missing email, at the moment they are about to send.

Uses the copy from the issue verbatim:

> Not seeing emails in your inbox? First make sure to check spam. If that doesn't work, please use the feedback widget in the corner and a team member will work with you promptly.

It lives in `en.yaml` as `emails.delivery_note` rather than hardcoded in the component, so it is translatable and editable by a writer without touching code.

### Not done here

The issue also floats expanding this into a helper that explains the individual email error messages from #713, linked from this note. That needs those messages catalogued first and is a bigger change than a line above a button — worth its own issue if you want it.

### Note on overlap

Touches `SendEmailDialog.tsx`, as does #1287 (the stale recipient count). The hunks are far apart — that one is in `getVoterCount` and the button's `disabled`, this one adds a `Typography` above the button row — so they should merge cleanly in either order. Happy to rebase whichever lands second.

## Related Issues

Closes #1270
