### PR TITLE
fix(ballot): give the ballot bubbles an explicit text colour

### DIFF
--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -315,6 +315,17 @@ code {
   cursor: pointer;
 }
 
+/* A <button> does not inherit .ballot's color — it takes the UA stylesheet's
+   ButtonText. That is black on desktop and Android, which is why nobody set a
+   colour here, but on iOS WebKit it resolves to the system tint and the score
+   digits came out blue (#1272) — including inside filled bubbles, where the
+   digit is meant to disappear against the black fill. Stating the colour makes
+   every platform render what desktop already did. */
+.circle,
+.oval {
+  color: var(--brand-black);
+}
+
 .circle.filled,
 .oval.filled {
   background-color: black;


### PR DESCRIPTION
## Description

Closes #1272. The score digits inside the ballot bubbles never had a colour set — not in `BubbleGrid.tsx` (its `fontSX` is font-size only), not in `index.css` (`.circle` sets background and border), and not by MUI, because these are native `<button>` elements rather than MUI Buttons.

**A `<button>` does not inherit `.ballot`'s `color: var(--brand-black)`.** It takes the UA stylesheet's `ButtonText`, which resolves to black on desktop and Android — masking the omission for years — and to the system tint on iOS WebKit, which is where the blue comes from. Chrome on iOS is WebKit, so it behaves the same as Safari here.

Two details in the screenshots pin it down:

- The **header star digits** in the same picture are black — and they are the only ballot digits *not* inside a button.
- The blue appears inside **filled** bubbles too, where the digit is meant to vanish against the black fill. That is the *"in some cases"* in the report: the same wrong colour, invisible everywhere else.

Every other candidate mechanism is absent: no `-webkit-text-fill-color` anywhere, no `appearance` resets, no `:visited`/`:link` rules, no `format-detection` meta (and single digits would not be linkified anyway), and the one global anchor rule is `a { color: var(--brand-pop) }` — which is **green**, not blue.

### Verification, and its limit

Verified in Chromium that the bubbles are `BUTTON` elements and that the computed colour of both plain and filled bubbles is unchanged at `rgb(0, 0, 0)` — so this is a no-op where it already worked, which is the point.

**Not verified on an iPhone.** I have no device, and Playwright's WebKit build isn't installed here. The diagnosis is from the markup and the CSS, and it explains all four observations; but if the blue survives this on a real device, the cause is elsewhere.

## Related Issues

Closes #1272
