### PR TITLE
fix(i18n): stop promising BetterVoting emails the voting links

### DIFF
--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -927,7 +927,7 @@ wizard:
 
   email_list_title: BetterVoting-managed voter IDs
   email_list_title_with_tip: $t(wizard.email_list_title) !tip(email_list)
-  email_list_description: Provide voter emails. BetterVoting will create private voting links and send them by email once the election starts
+  email_list_description: Provide voter emails. BetterVoting creates a private voting link for each voter, ready for you to send from the Voters tab
 
   id_list_title: Admin-managed voter IDs
   id_list_title_with_tip: $t(wizard.id_list_title) !tip(id_list)


### PR DESCRIPTION
## Description

Fixes #1558 — option 1, the smallest change that makes the product honest.

The email-list option in the election wizard currently tells admins:

> BetterVoting will create private voting links and **send them by email once the election starts**

**It doesn't.** Nothing is sent automatically — not on finalize, not on opening.

Changed to describe what actually happens, keeping the parallel shape of the neighbouring `id_list_description` (*"Provide X. \<what happens\>"*):

> Provide voter emails. BetterVoting creates a private voting link for each voter, **ready for you to send from the Voters tab**

## Why this matters more than a wording nit

An admin who believes the wizard finalizes, waits for the start time, and runs the **entire voting window without a single voter being told**. Nothing warns them — there's no error, and the Voters tab shows the roll exactly as expected throughout. The failure is only visible once the election is over.

## Verified against source

- `finalizeElectionController.ts` changes state, defaults `max_rankings`, deletes draft ballots. **No email call.**
- **No scheduler exists** — no cron, `node-schedule` or interval anywhere under `packages/backend/src` — so nothing could fire "once the election starts" either.
- The only send paths are `sendInvitesController.ts` / `sendEmailController.ts`, both admin-invoked.

## Scope

`en.yaml` only. `es`, `pl` and `pt-BR` don't define this key and fall back to English, so no translation is left promising the old behaviour.

The string is consumed in **two** places — the wizard's voter-access step, and the security-option card via `$t(wizard.email_list_description)` — and reads correctly in both. YAML validated.

## Notes for the reviewer

**Not fixed here, deliberately:** the card renders as `…from the Voters tab Recommended to maximize security.` — no separator, because the string has no trailing period and `$t()` concatenates directly. That run-on exists today with the old copy, and identically on the sibling `id_list_description` card. It's a pre-existing formatting quirk affecting both cards, so it seemed better as its own small change than smuggled into a copy fix. Happy to include it if you'd prefer.

**#1558 also raises two larger options** — sending on finalize, or prompting to send as part of the finalize flow (probably the best UX, since the flow already routes admins to the Voters tab). This change doesn't preclude either; it just stops the UI making a promise nothing keeps in the meantime.

## Screenshots / Videos (frontend only)

Text-only i18n change, no layout impact. The string appears in two places during election creation: the voter-access step of the wizard, and the "Email list" security-option card. Happy to add screenshots if useful.

## Related Issues

Fixes #1558. Context in #1556 — two help pages had transcribed this copy faithfully and stated invitations are sent automatically; both are now corrected.
