### PR TITLE
Fill Priority 0 translation gaps in es, pl, and pt-BR

### DIFF
--- a/packages/frontend/src/i18n/es.yaml
+++ b/packages/frontend/src/i18n/es.yaml
@@ -15,6 +15,26 @@ election_home:
   drafted: Esta elección está en fase de elaboración
   archived: Esta elección se ha archivado
 
+election_history:
+  title: Registro de Auditoría de la Elección
+  subtitle: Un registro público de todo lo que ha ocurrido con esta elección desde que fue finalizada.
+  ladder_note: 'Nota: los conteos de boletas se reportan solo en hitos específicos (1, 5, 10, 25, 50, 100, 250, ...) para proteger la privacidad de los votantes, y las ediciones de boletas usan una escala más fina (1, 2, 5, 10, 25, ...). Por la misma razón, los eventos relacionados con boletas se reportan con precisión de día.'
+  link: Registro de Auditoría
+  loading: Cargando el registro de auditoría…
+  empty: Aún no se han registrado eventos.
+  not_finalized: Esta elección aún no ha sido finalizada, por lo que no hay registro de auditoría disponible.
+  # Column headers and event chip labels live in EnhancedTable's head cell pool,
+  # which keys its group filters and chip colours off plain English strings.
+  desc:
+    state_initial: 'La elección entró en el estado "{{to}}"'
+    state_change: 'El estado cambió de "{{from}}" a "{{to}}"'
+    preliminary_on: Resultados preliminares habilitados
+    preliminary_off: Resultados preliminares deshabilitados
+    ballots_milestone: 'Las boletas emitidas alcanzaron {{count}}'
+    upload_ballots: 'Un administrador cargó {{count}} boleta(s)'
+    edits_milestone: 'Las ediciones de boletas alcanzaron {{count}}'
+    voter_revealed: Un administrador usó la herramienta de emergencia para revelar el ID de un votante
+
 # Ballot (ex. https://bettervoting.com/j87vqp/vote)
 ballot:
   this_election_uses: Esta {{election}} usará el {{voting_method}} para eligir a {{spelled_count}} $t(winner.winner).
@@ -26,11 +46,20 @@ ballot:
   submit_ballot: Enviar
   submitting: Enviando...
 
+  # Draggable RCV UI strings
+  available: Candidatos disponibles
+  yourRankings: Su clasificación
+  drop_here: Suelte aquí a los candidatos para clasificarlos
+  no_available: No hay candidatos disponibles
+  instructions: Arrastre a los candidatos de la lista izquierda a la derecha. Los candidatos a la derecha forman su orden de preferencia; los de la izquierda quedan sin clasificar.
+  instructions_rcv_draggable: Arrastre a los candidatos de izquierda → derecha. La posición 1 es su primera opción. Sin clasificar significa sin preferencia.
+
   dialog_submit_title: Enviar {{capital_ballot}}?
   dialog_send_receipt: Enviar recibo de votación por email? 
   dialog_email_placeholder: Recibo por email 
   dialog_cancel: Cancelar
   dialog_submit: Enviar
+  dialog_abstention: Abstención - No se expresó ninguna preferencia
   warnings:
     skipped_rank: No omita preferencias. Ordene a los candidatos para mostrar claramente sus preferencias. Los candidatos que se dejen en blanco se clasificarán en último lugar.
     duplicate_rank: No clasifique a varios candidatos por igual. (Clasificar a los candidatos por igual puede anular su voto.)
@@ -47,7 +76,7 @@ ballot:
       heading_prefix: ''
     star_pr:
       instruction_bullets:
-       - Dele a su(s) favorito(s) cinco estrellas.
+       - Dele a su(s) {{candidate}}(s) favorito(s) cinco estrellas.
        - Dele cero estrellas a su última opción o déjelo en blanco.
        - Calfique a otros {{candidates}} según lo desee.
        - Las puntuaciones iguales indican el mismo apoyo.
@@ -99,7 +128,7 @@ ballot:
         - '{{capital_candidates}} dejados en blanco se clasifican como último de su preferencia.'
       footer_single_winner: |
         {{capital_candidates}} son comparados en enfrentamientos cara a cara.
-        Un {{candidate}} gana un enfrentamiento si es mejor valorado que otro {{candidate}} por el número de votos.
+        Un {{candidate}} gana un enfrentamiento si es mejor valorado que el oponente por más votantes.
       left_title: ''
       right_title: ''
     choose_one:
@@ -116,6 +145,7 @@ support_blurb: Para asistencia con esta {{election}} por favor contacte a [{{ema
 # Share Button dropdown (ex. https://bettervoting.com/pres24/thanks)
 share:
   button: Compartir {{capital_election}}
+  button_results: Compartir resultados de {{capital_election}}
   facebook: Facebook
   X: X
   reddit: Reddit
@@ -176,6 +206,13 @@ ballot_submitted:
   results: Resultados
   donate: Donar a Equal Vote para apoyar el software de votación de código abierto.
   end_time: '{{capital_election}} termina el {{date}} a las {{time}}'
+  update_ballot_disabled: Esta elección no permite actualizar las boletas. Todas las boletas son definitivas una vez enviadas
+  update_ballot_enabled_open: Puede actualizar su boleta usando el enlace en su recibo por email
+  update_ballot_enabled_closed: La elección ha cerrado. Todas las boletas son definitivas
+  status: 'Estado:'
+  precinct: 'Recinto:'
+  ballot_id: 'ID de la boleta:'
+  update_ballot: 'Actualizar boleta:'
 
 # Localisation for numbers
 number:
@@ -186,6 +223,8 @@ number:
 
 # Results Example: bettervoting.com/tcvc7r/results
 results:
+  admin_results_toggle: 'Los resultados de {{capital_election}} son públicos !tip(public_results)'
+
   preliminary_title: RESULTADOS PRELIMINARES
   official_title: RESULTADOS OFICIALES
   election_title: |
@@ -196,6 +235,9 @@ results:
   loading_election: Cargando {{capital_election}}...
   details: Detalles de la Contienda
   additional_info: Estadísticas para Nerds
+  not_enough_candidates: |
+    Esta contienda actualmente solo tiene un candidato.
+    Los resultados se mostrarán cuando los administradores de la elección aprueben candidatos adicionales.
   waiting_for_results: |
     Todavía esperando por resultados
     Ningún voto se ha emitido
@@ -203,12 +245,15 @@ results:
     Hay un solo voto hasta ahora.
     Los resultados totales serán mostrados una vez se hayan emitido más votos.
   tie_title: '¡Empate!'
-  random_tiebreak_subtitle: '{{names}} ganó después de un desempate.'
+  random_tiebreak_subtitle: '{{names}} ganó después de un desempate !tip(random_tie_order)'
+  win_long_title_prefix: '⭐Ganadores⭐'
   win_title_postfix_one: '¡Gana!'
   win_title_postfix: '¡Ganan!'
   vote_count: '{{n}} votantes'
   method_context: 'Método de votación: {{voting_method}}'
   learn_link_text: Cómo {{voting_method}} funciona
+
+  admin_title: Controles de Resultados del Administrador
 
   choose_one:
     bar_title: Votos por {{capital_candidate}}
@@ -242,6 +287,7 @@ results:
     exhausted: Agotados
     tabulation_candidate_column: '{{capital_candidate}}'
     round_column: Ronda {{n}}
+    bloc_results_title: Primera y última ronda para determinar a cada ganador
 
   stv:
     table_title: Rondas de Tabulación del VUT
@@ -256,6 +302,7 @@ results:
       - Cada voto se le suma al finalista preferido por el elector.
       - El finalista con más votos gana.
     runoff_majority: mayoría de votantes con preferencia
+    runoff_no_preference_footnote: "El {{percentage}}% de los votantes no expresó preferencia entre los dos finalistas."
     score_table_title: Tabla de Puntuaciones
     score_table_columns:
       - '{{capital_candidate}}'
@@ -272,6 +319,7 @@ results:
     tiebreaker_note_text: 
       - Los desemptes se resuelven usando el [Protocolo Oficial de Desempate](https://starvoting.org/ties) siempre que sea posible.
       - Los empates son 10 veces menos probables con la Votación Estrella que con la Votación por Elección Única y generalmente se resuelven a medida que aumenta el número de votantes.
+      - Para entender cómo se resolvió el empate, recomendamos [aprender más sobre el Protocolo Oficial de Desempate de la Votación Estrella](https://starvoting.org/ties) y luego seguir los pasos a continuación para ver cómo se resolvió en esta elección.
     equal_preferences_title: Distribución de apoyo igualitario
     equal_preferences: Apoyo igualitario
     score_higher_than_runoff_title: ¿Por qué el candidato con mayor puntuación es diferente del ganador?
@@ -289,7 +337,7 @@ results:
     # Ultimately, the runoff winner becomes the final winner because they are preferred by more voters over the runner-up.
 
   star_pr:
-    chart_title: Resultados de la Ronda
+    chart_title: Resultados de la Ronda {{n}}
     table_title: Tabla de Resultados
     table_columns:
       - '{{capital_candidate}}'
@@ -319,8 +367,11 @@ keyword:
     candidate: candidato
     candidates: candidatos
     race: contienda
+    races: contiendas
+    race_title: título del cargo electo
     ballot: boleta
     vote: voto
+    votes: votos
 
   poll:
     election: encuesta
@@ -328,8 +379,11 @@ keyword:
     candidate: opción
     candidates: opciones
     race: pregunta
+    races: preguntas
+    race_title: título de la pregunta
     ballot: respuesta
     vote: respuesta
+    votes: respuestas
 
   # General Terms
   yes: Sí
@@ -338,6 +392,7 @@ keyword:
   save: Guardar
   cancel: Cancelar
   submit: Enviar
+  close: Cerrar
 
   # This is used in tables and charts
   total: Total

--- a/packages/frontend/src/i18n/pl.yaml
+++ b/packages/frontend/src/i18n/pl.yaml
@@ -11,6 +11,26 @@ election_home:
   drafted: Te wybory są jeszcze w fazie projektowania
   archived: Te wybory zostały zarchiwizowane
 
+election_history:
+  title: Dziennik audytu wyborów
+  subtitle: Publiczny zapis wszystkiego, co wydarzyło się w tych wyborach od momentu ich sfinalizowania.
+  ladder_note: 'Uwaga: liczba oddanych kart do głosowania jest raportowana tylko przy określonych progach (1, 5, 10, 25, 50, 100, 250, ...) w celu ochrony prywatności głosujących, a edycje kart korzystają z drobniejszej skali (1, 2, 5, 10, 25, ...). Z tego samego powodu zdarzenia dotyczące kart do głosowania są raportowane z dokładnością do dnia.'
+  link: Dziennik audytu
+  loading: Ładowanie dziennika audytu…
+  empty: Nie zarejestrowano jeszcze żadnych zdarzeń.
+  not_finalized: Te wybory nie zostały jeszcze sfinalizowane, więc dziennik audytu nie jest dostępny.
+  # Column headers and event chip labels live in EnhancedTable's head cell pool,
+  # which keys its group filters and chip colours off plain English strings.
+  desc:
+    state_initial: 'Wybory weszły w stan "{{to}}"'
+    state_change: 'Stan zmienił się z "{{from}}" na "{{to}}"'
+    preliminary_on: Wyniki wstępne włączone
+    preliminary_off: Wyniki wstępne wyłączone
+    ballots_milestone: 'Liczba oddanych kart do głosowania osiągnęła {{count}}'
+    upload_ballots: 'Administrator wgrał {{count}} kart(y) do głosowania'
+    edits_milestone: 'Liczba edycji kart do głosowania osiągnęła {{count}}'
+    voter_revealed: Administrator użył narzędzia awaryjnego, aby ujawnić identyfikator głosującego
+
 # Ballot (ex. https://bettervoting.com/j87vqp/vote)
 ballot:
   this_election_uses: Te {{election}} wykorzystują metodę głosowania {{voting_method}}, aby wybrać {{spelled_count}} $t(winner.winner)
@@ -22,11 +42,20 @@ ballot:
   submit_ballot: Wyślij
   submitting: Wysyłam...
 
+  # Draggable RCV UI strings
+  available: Dostępni kandydaci
+  yourRankings: Twój ranking
+  drop_here: Upuść tutaj kandydatów, aby ich uszeregować
+  no_available: Brak dostępnych kandydatów
+  instructions: Przeciągnij kandydatów z listy po lewej stronie na prawą. Kandydaci po prawej tworzą Twój ranking; po lewej pozostają nieuszeregowani.
+  instructions_rcv_draggable: Przeciągnij kandydatów z lewej → na prawą. Pozycja 1 to Twój najlepszy wybór. Nieuszeregowani oznaczają brak preferencji.
+
   dialog_submit_title: Wyślij {{capital_ballot}}?
   dialog_send_receipt: Czy wysłać e-mail z potwierdzeniem głosowania? 
   dialog_email_placeholder: Potwierdzenie e-mailem
   dialog_cancel: Anuluj
   dialog_submit: Wyślij
+  dialog_abstention: Wstrzymanie się - nie wyrażono żadnej preferencji
   warnings:
     skipped_rank: Nie pomijaj rankingów.  Uszereguj kandydatów, wskazując swoje preferencje.  Niewybrani kandydaci będą na końcu.
     duplicate_rank: Nie przyznawaj równej pozycji kilku kandydatom. (Równe rankingi mogą unieważnić Twój głos.)
@@ -43,7 +72,7 @@ ballot:
       heading_prefix: ''
     star_pr:
       instruction_bullets:
-       - Give your favorite(s) five stars.
+       - Give your favorite {{candidate}}(s) five stars.
        - Give your last choice(s) zero stars or leave blank.
        - Score other {{candidates}} as desired.
        - Equal scores indicate equal support.
@@ -82,6 +111,14 @@ ballot:
         in a round, they are elected.
       left_title: ''
       right_title: ''
+    stv: 
+      instruction_bullets:
+        - Uszereguj {{candidates}} w kolejności preferencji (1., 2., 3. itd.).
+        - Nadawanie równych pozycji nie jest dozwolone ({{candidates}} muszą mieć różne pozycje).
+        - '{{capital_candidates}} pozostawieni bez pozycji trafiają na koniec'
+      footer_multi_winner: ''
+      left_title: ''
+      right_title: ''
     ranked_robin:
       instruction_bullets:
         - Rank the {{candidates}} in order of preference.
@@ -106,6 +143,7 @@ support_blurb: For support on this {{election}} please contact [{{email}}](mailt
 # Share Button dropdown (ex. https://bettervoting.com/pres24/thanks)
 share:
   button: Share {{capital_election}}
+  button_results: 'Udostępnij wyniki: {{capital_election}}'
   facebook: Facebook
   X: X
   reddit: Reddit
@@ -166,16 +204,25 @@ ballot_submitted:
   results: Results
   donate: Donate to Equal Vote to support open source voting software
   end_time: '{{capital_election}} ends {{date}} at {{time}}'
+  update_ballot_disabled: Te wybory nie pozwalają na aktualizowanie kart do głosowania. Wszystkie karty są ostateczne po wysłaniu
+  update_ballot_enabled_open: Możesz zaktualizować swoją kartę do głosowania, korzystając z linku w e-mailu z potwierdzeniem
+  update_ballot_enabled_closed: Wybory zostały zakończone. Wszystkie karty do głosowania są ostateczne
+  status: 'Status:'
+  precinct: 'Obwód:'
+  ballot_id: 'ID karty do głosowania:'
+  update_ballot: 'Aktualizuj kartę do głosowania:'
 
 # Localisation for numbers
 number:
-  rank_ordinal_one: "{{count}}st"
-  rank_ordinal_two: "{{count}}nd"
-  rank_ordinal_few: "{{count}}rd"
-  rank_ordinal_other: "{{count}}th"
+  rank_ordinal_one: "{{count}}."
+  rank_ordinal_two: "{{count}}."
+  rank_ordinal_few: "{{count}}."
+  rank_ordinal_other: "{{count}}."
 
 # Results Example: bettervoting.com/tcvc7r/results
 results:
+  admin_results_toggle: '{{capital_election}} - wyniki są publiczne !tip(public_results)'
+
   preliminary_title: PRELIMINARY RESULTS
   official_title: OFFICIAL RESULTS
   election_title: |
@@ -186,6 +233,9 @@ results:
   loading_election: Loading {{capital_election}}...
   details: Race Details
   additional_info: Stats for Nerds
+  not_enough_candidates: |
+    Ta rywalizacja ma obecnie tylko jednego kandydata.
+    Wyniki zostaną wyświetlone, gdy administratorzy wyborów zatwierdzą dodatkowych kandydatów.
   waiting_for_results: |
     Still waiting for results
     No votes have been cast
@@ -193,12 +243,15 @@ results:
     There's only one vote so far.
     Full results will be displayed once there's more votes.
   tie_title: 'Tied!'
-  random_tiebreak_subtitle: '{{names}} won after tie breaker'
+  random_tiebreak_subtitle: '{{names}} won after tie breaker !tip(random_tie_order)'
+  win_long_title_prefix: '⭐Zwycięzcy⭐'
   win_title_postfix_one: 'Wins!'
   win_title_postfix: 'Win!'
   vote_count: '{{n}} voters'
   method_context: 'Voting Method: {{voting_method}}'
   learn_link_text: How {{voting_method}} works
+
+  admin_title: Panel administratora wyników
 
   choose_one:
     bar_title: Votes for each {{capital_candidate}}
@@ -232,6 +285,10 @@ results:
     exhausted: Exhausted
     tabulation_candidate_column: '{{capital_candidate}}'
     round_column: Round {{n}}
+    bloc_results_title: Pierwsza i ostatnia runda wyłaniania każdego zwycięzcy
+
+  stv:
+    table_title: Rundy tabulacji STV
 
   star:
     score_title: Scoring Round
@@ -243,6 +300,7 @@ results:
       - Each vote goes to the voter's preferred finalist.
       - Finalist with most votes wins.
     runoff_majority: majority of voters with preference
+    runoff_no_preference_footnote: "{{percentage}}% głosujących nie wyraziło preferencji między dwoma finalistami."
     score_table_title: Scores Table
     score_table_columns:
       - '{{capital_candidate}}'
@@ -259,6 +317,7 @@ results:
     tiebreaker_note_text: 
       - Ties are broken using the [Offical Tiebreaker Protocol](https://starvoting.org/ties) whenever possible.
       - Ties are 10 times less likely to occur with STAR Voting than with Choose-One Voting and generally resolve as the number of voters increases.
+      - Aby zrozumieć, jak rozstrzygnięto remis, zalecamy [zapoznać się z oficjalnym protokołem rozstrzygania remisów w głosowaniu STAR](https://starvoting.org/ties), a następnie prześledzić poniższe kroki, aby zobaczyć, jak rozstrzygnięto go w tych wyborach.
     equal_preferences_title: Distribution of Equal Support
     equal_preferences: Equal Support
     score_higher_than_runoff_title: Why is the top scoring candidate different from the winner?
@@ -276,7 +335,7 @@ results:
     # Ultimately, the runoff winner becomes the final winner because they are preferred by more voters over the runner-up.
 
   star_pr:
-    chart_title: Round Results
+    chart_title: Round {{n}} Results
     table_title: Results Table
     table_columns:
       - '{{capital_candidate}}'
@@ -306,8 +365,11 @@ keyword:
     candidate: candidate
     candidates: candidates
     race: race
+    races: rywalizacje
+    race_title: nazwa wybieranego urzędu
     ballot: ballot
     vote: vote
+    votes: głosy
 
   poll:
     election: poll
@@ -315,8 +377,11 @@ keyword:
     candidate: option
     candidates: options
     race: question
+    races: pytania
+    race_title: tytuł pytania
     ballot: response
     vote: response
+    votes: odpowiedzi
 
   # General Terms
   yes: Yes
@@ -325,6 +390,7 @@ keyword:
   save: Save
   cancel: Cancel
   submit: Submit
+  close: Zamknij
 
   # This is used in tables and charts
   total: Total 

--- a/packages/frontend/src/i18n/pt-BR.yaml
+++ b/packages/frontend/src/i18n/pt-BR.yaml
@@ -14,6 +14,26 @@ election_home:
   drafted: Esta eleição ainda está em rascunho
   archived: Esta eleição foi arquivada
 
+election_history:
+  title: Registro de Auditoria da Eleição
+  subtitle: Um registro público de tudo o que aconteceu com esta eleição desde que foi finalizada.
+  ladder_note: 'Nota: as contagens de cédulas são reportadas apenas em marcos específicos (1, 5, 10, 25, 50, 100, 250, ...) para proteger a privacidade dos eleitores, e as edições de cédulas usam uma escala mais fina (1, 2, 5, 10, 25, ...). Pela mesma razão, os eventos relacionados a cédulas são reportados com precisão de dia.'
+  link: Registro de Auditoria
+  loading: Carregando registro de auditoria…
+  empty: Nenhum evento registrado ainda.
+  not_finalized: Esta eleição ainda não foi finalizada, portanto nenhum registro de auditoria está disponível.
+  # Column headers and event chip labels live in EnhancedTable's head cell pool,
+  # which keys its group filters and chip colours off plain English strings.
+  desc:
+    state_initial: 'A eleição entrou no estado "{{to}}"'
+    state_change: 'O estado mudou de "{{from}}" para "{{to}}"'
+    preliminary_on: Resultados preliminares habilitados
+    preliminary_off: Resultados preliminares desabilitados
+    ballots_milestone: 'As cédulas depositadas alcançaram {{count}}'
+    upload_ballots: 'Um administrador carregou {{count}} cédula(s)'
+    edits_milestone: 'As edições de cédulas alcançaram {{count}}'
+    voter_revealed: Um administrador usou a ferramenta de emergência para revelar o ID de um eleitor
+
 # Ballot (ex. https://bettervoting.com/j87vqp/vote)
 ballot:
   this_election_uses: Esta {{election}} usará {{voting_method}} para eleger {{spelled_count}} $t(winner.winner).
@@ -25,11 +45,20 @@ ballot:
   submit_ballot: Enviar
   submitting: Enviando...
 
+  # Draggable RCV UI strings
+  available: Candidatos disponíveis
+  yourRankings: Suas classificações
+  drop_here: Solte os candidatos aqui para classificá-los
+  no_available: Nenhum candidato disponível
+  instructions: Arraste os candidatos da lista da esquerda para a da direita. Os candidatos à direita formam sua ordem de classificação; à esquerda ficam sem classificação.
+  instructions_rcv_draggable: Arraste os candidatos da esquerda → direita. A posição 1 é sua primeira escolha. Sem classificação significa sem preferência.
+
   dialog_submit_title: Enviar {{capital_ballot}}?
   dialog_send_receipt: Enviar recibo da cédula por e-mail?
   dialog_email_placeholder: E-mail para recibo
   dialog_cancel: Cancelar
   dialog_submit: Enviar
+  dialog_abstention: Abstenção - Nenhuma preferência foi expressa
   warnings:
     skipped_rank: Não pule classificações. Classifique os candidatos para mostrar claramente suas preferências. Candidatos deixados em branco são classificados por último.
     duplicate_rank: Não classifique múltiplos candidatos igualmente. (Classificar candidatos igualmente pode invalidar sua cédula.)
@@ -46,7 +75,7 @@ ballot:
       heading_prefix: ''
     star_pr:
       instruction_bullets:
-       - Dê cinco estrelas para seu(s) favorito(s).
+       - Dê cinco estrelas para seu(s) {{candidate}}(s) favorito(s).
        - Dê zero estrelas ou deixe em branco sua(s) última(s) escolha(s).
        - Avalie outros {{candidates}} conforme desejado.
        - Notas iguais indicam preferência igual.
@@ -84,6 +113,14 @@ ballot:
         Se seu voto não puder ser transferido, ele não será contado nas rodadas posteriores. Se um candidato tiver a maioria dos votos restantes em uma rodada, ele é eleito.
       left_title: ''
       right_title: ''
+    stv: 
+      instruction_bullets:
+        - Classifique os {{candidates}} em ordem de preferência. (1º, 2º, 3º, etc.)
+        - Não é permitido classificar {{candidates}} igualmente.
+        - '{{capital_candidates}} deixados em branco são classificados por último'
+      footer_multi_winner: ''
+      left_title: ''
+      right_title: ''
     ranked_robin:
       instruction_bullets:
         - Classifique os {{candidates}} em ordem de preferência.
@@ -108,6 +145,7 @@ support_blurb: Para suporte nesta {{election}} entre em contato com [{{email}}](
 # Share Button dropdown (ex. https://bettervoting.com/pres24/thanks)
 share:
   button: Compartilhar {{capital_election}}
+  button_results: Compartilhar resultados de {{capital_election}}
   facebook: Facebook
   X: X
   reddit: Reddit
@@ -168,6 +206,13 @@ ballot_submitted:
   results: Resultados
   donate: Doe para Equal Vote para apoiar software de votação de código aberto
   end_time: '{{capital_election}} termina {{date}} às {{time}}'
+  update_ballot_disabled: Esta eleição não permite atualizações de cédulas. Todas as cédulas são definitivas após o envio
+  update_ballot_enabled_open: Você pode atualizar sua cédula usando o link no recibo enviado ao seu e-mail
+  update_ballot_enabled_closed: A eleição foi encerrada. Todas as cédulas são definitivas
+  status: 'Status:'
+  precinct: 'Zona eleitoral:'
+  ballot_id: 'ID da cédula:'
+  update_ballot: 'Atualizar cédula:'
 
 # Localisation for numbers
 number:
@@ -178,6 +223,8 @@ number:
 
 # Results Example: bettervoting.com/tcvc7r/results
 results:
+  admin_results_toggle: 'Os resultados de {{capital_election}} são públicos !tip(public_results)'
+
   preliminary_title: RESULTADOS PRELIMINARES
   official_title: RESULTADOS OFICIAIS
   election_title: |
@@ -188,6 +235,9 @@ results:
   loading_election: Carregando {{capital_election}}...
   details: Detalhes da Disputa
   additional_info: Estatísticas para Nerds
+  not_enough_candidates: |
+    Esta disputa atualmente tem apenas um candidato.
+    Os resultados serão exibidos quando os administradores da eleição aprovarem candidatos adicionais.
   waiting_for_results: |
     Ainda esperando pelos resultados
     Nenhum voto foi registrado
@@ -195,12 +245,15 @@ results:
     Há apenas um voto até agora.
     Os resultados completos serão exibidos quando houver mais votos.
   tie_title: 'Empate!'
-  random_tiebreak_subtitle: '{{names}} venceu após o desempate'
+  random_tiebreak_subtitle: '{{names}} venceu após o desempate !tip(random_tie_order)'
+  win_long_title_prefix: '⭐Vencedores⭐'
   win_title_postfix_one: 'Vence!'
   win_title_postfix: 'Vencem!'
   vote_count: '{{n}} eleitores'
   method_context: 'Método de Votação: {{voting_method}}'
   learn_link_text: Como {{voting_method}} funciona
+
+  admin_title: Controles de Resultados do Administrador
 
   choose_one:
     bar_title: Votos para cada {{capital_candidate}}
@@ -234,6 +287,10 @@ results:
     exhausted: Exaustos
     tabulation_candidate_column: '{{capital_candidate}}'
     round_column: Rodada {{n}}
+    bloc_results_title: Primeira e última rodada para determinar cada vencedor
+
+  stv:
+    table_title: Rodadas de Tabulação do STV
 
   star:
     score_title: Rodada de Pontuação
@@ -245,6 +302,7 @@ results:
       - Cada voto vai para o finalista preferido do eleitor.
       - O finalista com mais votos vence.
     runoff_majority: maioria dos eleitores com preferência
+    runoff_no_preference_footnote: "{{percentage}}% dos eleitores não expressaram preferência entre os dois finalistas."
     score_table_title: Tabela de Pontuação
     score_table_columns:
       - '{{capital_candidate}}'
@@ -261,6 +319,7 @@ results:
     tiebreaker_note_text: 
       - Empates são resolvidos usando o [Protocolo Oficial de Desempate](https://starvoting.org/ties) sempre que possível.
       - Empates são 10 vezes menos prováveis de ocorrer com o STAR Voting do que com o método vote-apenas-um e geralmente se resolvem à medida que o número de eleitores aumenta.
+      - Para entender como o empate foi resolvido, recomendamos [aprender mais sobre o Protocolo Oficial de Desempate do STAR Voting](https://starvoting.org/ties) e depois seguir os passos abaixo para ver como ele foi resolvido nesta eleição.
     equal_preferences_title: Distribuição de Preferências Iguais
     equal_preferences: Preferências Iguais
     score_higher_than_runoff_title: Por que o candidato com maior pontuação é diferente do vencedor?
@@ -278,7 +337,7 @@ results:
     # Ultimately, the runoff winner becomes the final winner because they are preferred by more voters over the runner-up.
 
   star_pr:
-    chart_title: Resultados por Rodada
+    chart_title: Resultados da Rodada {{n}}
     table_title: Tabela de Resultados
     table_columns:
       - '{{capital_candidate}}'
@@ -308,8 +367,11 @@ keyword:
     candidate: candidato
     candidates: candidatos
     race: disputa
+    races: disputas
+    race_title: título do cargo eletivo
     ballot: cédula
     vote: voto
+    votes: votos
 
   poll:
     election: enquete
@@ -317,8 +379,11 @@ keyword:
     candidate: opção
     candidates: opções
     race: pergunta
+    races: perguntas
+    race_title: título da pergunta
     ballot: resposta
     vote: resposta
+    votes: respostas
 
   # General Terms
   yes: Sim
@@ -327,6 +392,7 @@ keyword:
   save: Salvar
   cancel: Cancelar
   submit: Enviar
+  close: Fechar
 
   # This is used in tables and charts
   total: Total 


### PR DESCRIPTION
## Description

The three existing translation files had drifted behind `en.yaml` and were missing Priority 0 strings. This PR brings **es**, **pl**, and **pt-BR** up to full Priority 0 coverage (255 leaf strings), the same coverage the new German translation (#1560) ships with. Per the translation guide, only Priority 0 was touched — nothing after the `#### PRIORITY 1` banner.

**Before → after (Priority 0 keys present):**

| file | before | after | added |
|---|---|---|---|
| es.yaml | 212 | 255 | 44 |
| pl.yaml | 205 | 255 | 51 |
| pt-BR.yaml | 205 | 255 | 51 |

What was added in all three: the whole new `election_history` section (15 keys), the draggable-ballot UI strings, `dialog_abstention`, `share.button_results`, the `ballot_submitted` status/receipt block, `results.admin_results_toggle` / `not_enough_candidates` / `win_long_title_prefix` / `admin_title` / `rcv.bloc_results_title` / `star.runoff_no_preference_footnote`, the third `star.tiebreaker_note_text` paragraph, and the `keyword` `races` / `race_title` / `votes` / `close` vocabulary. pl and pt-BR additionally gained the `ballot.methods.stv` block and `results.stv.table_title`.

**Interpolation-token repairs to existing strings** (tokens now match English exactly in every key): `!tip(random_tie_order)` restored to `results.random_tiebreak_subtitle`, `{{n}}` to `results.star_pr.chart_title`, and `{{candidate}}` to the first star_pr instruction bullet in all three files; the Spanish `ranked_robin.footer_single_winner` had a duplicated `{{candidate}}` (now "el oponente"). Polish `number.rank_ordinal_*` entries were still English-shaped (`1st`/`2nd`/`3rd`) and now use the Polish ordinal form `{{count}}.` (es and pt-BR ordinals were already correct for their languages).

**Verification** (script flattens each file and diffs key paths and sorted token lists against Priority 0 of `en.yaml`):

```
en Priority-0 leaves: 255
es:    has 256 | missing 0 | extra 1 | token mismatches 0
pl:    has 256 | missing 0 | extra 1 | token mismatches 0
pt-BR: has 256 | missing 0 | extra 1 | token mismatches 0
```

The 1 "extra" in each file is `results.single_vote`, a stale leftover: it no longer exists in `en.yaml` and nothing in the frontend references it. It was deliberately left in place rather than deleted as a side effect of this PR — happy to drop it (in all three files) if you prefer. Key insertion order matches `en.yaml`, so the files stay diffable against the source; keys already translated were not re-translated.

### Honesty note — these are AI-produced translations

This PR was produced with AI assistance (Claude). The translation guide asks for a native-speaker proof-reader, and that review has **not** happened yet — please treat every added string as needing native review before these are relied on. Specific places a reviewer should look first:

- **Polish grammatical case:** interpolated nouns arrive in nominative, but several English templates use them as objects. `ballot.methods.stv.instruction_bullets[0]` ("Uszereguj {{candidates}} …") needs accusative *kandydatów*, so it will read wrong once `keyword.election.candidates` is translated; bullets 1–2 and `results.admin_results_toggle` were rephrased ("{{capital_election}} - wyniki są publiczne") to keep the noun in nominative. `share.button_results` uses a colon for the same reason. A native speaker may find better constructions.
- **Gender agreement (es/pt-BR):** the star_pr bullet now reads "su(s) {{candidate}}(s) favorito(s)" / "seu(s) {{candidate}}(s) favorito(s)" — masculine agreement is correct for *candidato* but not for the poll vocabulary's *opción/opção*. English's own "(s)" hedge was mirrored; there is no phrasing that agrees with both vocabularies.
- **New terminology minted here:** "Registro de Auditoría / Registro de Auditoria / Dziennik audytu" for *Audit Log*; "Recinto" (es) / "Zona eleitoral" (pt-BR) / "Obwód" (pl) for *Precinct*; "herramienta de emergencia / ferramenta de emergência / narzędzie awaryjne" for the *break-glass tool*; `keyword.election.race_title` ("elected office title") in all three. These had no precedent in the files.
- **Polish `keyword` and other pre-existing untranslated strings:** much of pl.yaml's older content is still English placeholder text; per the no-re-translation scope, only the missing keys were added (in Polish), so some sections are now mixed-language until someone translates the rest.
- The es/pt-BR third `tiebreaker_note_text` paragraph slightly overlaps their older two-paragraph note, which already mentions the tiebreaker-protocol link; English's current three-paragraph text repeats it, and list lengths must match.

## Screenshots / Videos (frontend only)

Text-only translation changes; no visual/layout changes. (Strings render in the same components as the existing English keys.)

## Related Issues

- Follows up on #1560 (German translation, full Priority 0 coverage) — this brings the three pre-existing languages up to the same coverage.
