### PR TITLE
Stop the results endpoint 500ing on a race with no ballots

### DIFF
--- a/packages/backend/src/Tabulators/AllocatedScore.ts
+++ b/packages/backend/src/Tabulators/AllocatedScore.ts
@@ -149,7 +149,11 @@ export function AllocatedScore(candidates: candidate[], votes: rawVote[], nWinne
         let weight_on_split = findWeightOnSplit(cand_df, split_point);
 
         // quota = spent_above + weight_on_split*new_weight
-        let new_weight = (quota.sub(spent_above)).div(weight_on_split);
+        // weight_on_split is the total weight sitting exactly on the split point, so
+        // when it is zero there is no partially represented ballot to reweight and the
+        // surplus has nowhere to go. Dividing by it throws in fraction.js, which used to
+        // 500 the results endpoint for any race with no ballots.
+        let new_weight = weight_on_split.equals(0) ? new Fraction(0) : (quota.sub(spent_above)).div(weight_on_split);
         results.logs.push(
             `The ${rounded(weight_on_split)} voters who gave ${summaryData.candidates[w].name} ${rounded(split_point.mul(MAX_SCORE))} stars are partially represented. `+
             `${percent(new_weight)} of their remaining vote will go toward ${summaryData.candidates[w].name} and ${percent(new Fraction(1).sub(new_weight))} will be preserved for future rounds.`)
@@ -285,6 +289,9 @@ function findSplitPoint(cand_df_sorted: winner_scores[], quota: typeof Fraction)
             return c.weighted_score;
         }
     }
+
+    // No ballots at all, so there is no score to split on.
+    if (cand_df_sorted.length === 0) return new Fraction(0);
 
     return cand_df_sorted.slice(-1)[0].weighted_score
 }

--- a/packages/backend/src/Tabulators/AllocatedScore.ts
+++ b/packages/backend/src/Tabulators/AllocatedScore.ts
@@ -149,11 +149,12 @@ export function AllocatedScore(candidates: candidate[], votes: rawVote[], nWinne
         let weight_on_split = findWeightOnSplit(cand_df, split_point);
 
         // quota = spent_above + weight_on_split*new_weight
-        // weight_on_split is the total weight sitting exactly on the split point, so
-        // when it is zero there is no partially represented ballot to reweight and the
-        // surplus has nowhere to go. Dividing by it throws in fraction.js, which used to
-        // 500 the results endpoint for any race with no ballots.
-        let new_weight = weight_on_split.equals(0) ? new Fraction(0) : (quota.sub(spent_above)).div(weight_on_split);
+        // Only used for the log line below -- updateBallotWeights recomputes this
+        // division itself, behind the same guard. weight_on_split is the weight sitting
+        // exactly on the split point, so when it is zero there is no partially
+        // represented ballot to describe. Dividing by it throws in fraction.js, which
+        // used to 500 the results endpoint for any race with no ballots.
+        let new_weight = weight_on_split.compare(0) > 0 ? (quota.sub(spent_above)).div(weight_on_split) : new Fraction(0);
         results.logs.push(
             `The ${rounded(weight_on_split)} voters who gave ${summaryData.candidates[w].name} ${rounded(split_point.mul(MAX_SCORE))} stars are partially represented. `+
             `${percent(new_weight)} of their remaining vote will go toward ${summaryData.candidates[w].name} and ${percent(new Fraction(1).sub(new_weight))} will be preserved for future rounds.`)

--- a/packages/backend/src/Tabulators/IRV.test.ts
+++ b/packages/backend/src/Tabulators/IRV.test.ts
@@ -133,4 +133,45 @@ describe("IRV Tests", () => {
         expect(results.exhaustedVoteCounts).toStrictEqual([1,2,3]); 
         expect(results.nExhaustedViaOvervote).toBe(3); 
     })
+
+    test("No ballots have been cast yet", () => {
+        // Regression test for election mkvb4f, which 500'd its results page.
+        // With no votes at all nobody can reach the quota, so every round eliminates
+        // another candidate. Once the last one was gone the loop kept going and read
+        // remainingCandidates[0] off an empty array, throwing on .hareScores.
+        // STV survives this because it seats the survivors once they can fill the
+        // remaining seats; plain IRV has no such branch, so it has to stop instead.
+        const candidates = ['Alice', 'Bob', 'Carol']
+
+        const results = IRV(...mapMethodInputs(candidates, []), 2)
+        expect(results.elected.length).toBe(0);
+        expect(results.summaryData.nTallyVotes).toBe(0);
+    })
+
+    test("Single winner with no ballots", () => {
+        // The same crash never needed multiple seats: an ordinary single-winner IRV
+        // race that nobody had voted in yet was enough to take the results page down.
+        const candidates = ['Alice', 'Bob', 'Carol']
+
+        const results = IRV(...mapMethodInputs(candidates, []))
+        expect(results.elected.length).toBe(0);
+    })
+
+    test("Every ballot exhausts before the seats are filled", () => {
+        // Bloc IRV, two seats, every voter ranking only Alice. Alice takes the majority
+        // and wins seat one; the pool is rebuilt as Bob and Carol and every ballot is
+        // redistributed, but none of them rank either candidate, so all are exhausted.
+        // With no active votes left neither can reach the quota, so both are eliminated
+        // and seat two is simply left unfilled rather than crashing.
+        const candidates = ['Alice', 'Bob', 'Carol']
+
+        const votes = [
+            [1, 0, 0, 0],
+            [1, 0, 0, 0],
+            [1, 0, 0, 0],
+        ]
+        const results = IRV(...mapMethodInputs(candidates, votes), 2)
+        expect(results.elected.length).toBe(1);
+        expect(results.elected[0].name).toBe('Alice');
+    })
 })

--- a/packages/backend/src/Tabulators/IRV.ts
+++ b/packages/backend/src/Tabulators/IRV.ts
@@ -75,7 +75,11 @@ export function IRV_STV(candidates: candidate[], votes: rawVote[], nWinners = 1,
         quota = Math.floor(activeVotes.length/2 + 1)
     }
 
-    while (results.elected.length < nWinners) {
+    // Stop once every candidate has been eliminated. When no active votes remain
+    // nobody can reach the quota, so each round eliminates one more candidate until
+    // the pool is empty and there is nothing left to seat. STV never gets here: the
+    // branch below seats the survivors as soon as they can fill the remaining seats.
+    while (results.elected.length < nWinners && remainingCandidates.length > 0) {
 
         if (DEBUG) console.log("IRV Round");
 

--- a/packages/backend/src/Tabulators/NoBallots.test.ts
+++ b/packages/backend/src/Tabulators/NoBallots.test.ts
@@ -1,0 +1,25 @@
+import { mapMethodInputs } from '../test/TestHelper'
+import { VotingMethods } from './VotingMethodSelecter'
+
+describe("Tabulating a race nobody has voted in", () => {
+    // Election mkvb4f 500'd its results page: seven races, fifteen candidates each,
+    // five seats each, and no ballots cast. IRV threw first, and once that was fixed
+    // STAR_PR threw a different error further down the same page, so the endpoint is
+    // only safe if every method can survive an empty ballot set. A race with no votes
+    // yet is ordinary -- any open election with preliminary results public is in this
+    // state until the first vote arrives.
+    const candidates = Array.from({ length: 15 }, (_, i) => `Candidate ${i + 1}`)
+
+    Object.keys(VotingMethods).forEach(method => {
+        test(`${method} tabulates with no ballots`, () => {
+            const [c, v] = mapMethodInputs(candidates, [])
+            const results = (VotingMethods as any)[method](c, v, 5, {})
+
+            expect(results).toBeDefined()
+            expect(results.summaryData.nTallyVotes).toBe(0)
+            // No votes means nobody can be preferred over anybody, so a method may
+            // legitimately seat nobody. What it must not do is throw.
+            expect(results.elected.length).toBeLessThanOrEqual(5)
+        })
+    })
+})


### PR DESCRIPTION
`https://bettervoting.com/mkvb4f/results` currently returns a 500. Two tabulators throw when a race has no votes in it, and since `getElectionResults` tabulates every race in one loop with no per-race error handling, either throw takes down the whole page for all seven races.

## The IRV crash

From the production log for that request:

```
ctx:c254e80d Tabulating results for Plurality election
ctx:c254e80d Tabulating results for IRV election
ctx:c254e80d Cannot read properties of undefined (reading 'hareScores')
ctx:c254e80d RES: GET /API/ElectionResult/mkvb4f  status:500
```

With no active votes nobody can reach the quota, so every round eliminates another candidate. Once the last one is gone the loop keeps running and reads `remainingCandidates[0]` off an empty array, throwing at `IRV.ts:99`.

STV never reaches this: the branch below seats the survivors as soon as they can fill the remaining seats, and that branch is gated on `proportional`. #1427 fixed the STV shape of this bug inside `distributeVotes` and its test notes that *"plain IRV can't hit this because its winner branch rebuilds the candidate pool"* — true right up until the pool empties by elimination instead.

**This is not limited to multi-winner races.** An ordinary single-winner IRV race that nobody has voted in yet crashes identically, so any open election with public preliminary results 500s its results page until the first vote arrives. There is a regression test for that case specifically.

## The STAR_PR crash behind it

Fixing IRV alone was not enough — the same page then threw somewhere else. STAR_PR builds its ballot table from the cast ballots, so with none it read `weighted_score` off an empty array in `findSplitPoint`, and past that divided the surplus by a zero `weight_on_split`, which throws in fraction.js. Both are guarded.

The `weight_on_split` guard is not only about empty races: it can reach zero with real ballots once the ballots on the split point have been spent, and that threw too.

## Behaviour note

IRV now seats fewer winners than `num_winners` when every ballot is exhausted. That is the honest answer -- there is nobody left with support to seat.

For the empty-ballot case this is invisible to users: `Results.tsx` gates the winners block on `nTallyVotes > 0`, so a race with no votes renders `waiting_for_results` ("Still waiting for results / No votes have been cast") regardless of what `elected` contains. That is the message the page was always meant to show here; it just never got the chance, because the API 500'd before the frontend had anything to render.

It is visible in the rarer case where ballots exist but all exhaust before the seats are filled (see the third new IRV test: three ballots, all ranking only Alice). There the page shows the winners that could actually be seated and no placeholder for the rest, which still seems right, but flagging it since it is a real change.

Note a ballot-count short-circuit in the controller would not have been sufficient on its own -- that exhaustion case has `nTallyVotes > 0` and crashed identically. Happy to add one as belt-and-braces if wanted.

I also considered wrapping each race in a try/catch so one bad race degrades to an error for that race instead of 500ing all seven. That is a bigger behavioural change and I did not want to bundle it here, but it would have contained this incident.

## Verification

- New `NoBallots` suite walks `VotingMethods`, so any method added later has to survive an empty ballot set.
- Reverting both source fixes with the tests in place: 5 tests fail with the exact production error, and pass with the fixes.
- Full backend suite: 24 suites, 174 tests passing. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
