### PR TITLE
fix(voters): stop showing "Invalid Voter ID" before the voter types anything

### DIFF
--- a/packages/frontend/src/components/Election/VoterAuth.tsx
+++ b/packages/frontend/src/components/Election/VoterAuth.tsx
@@ -44,7 +44,7 @@ const VoterAuth = () => {
 
   const isAuthorized = voterAuth?.authorized_voter
   const missingEmail = voterAuth?.required === "Email Validation Required"
-  const missingVoterID = voterAuth?.required === "Voter ID Required"
+  const missingVoterID = voterAuth?.required === "Voter ID Required for closed elections"
 
   return (
     <Box sx={{ p: 1, flexGrow: 1 }}>


### PR DESCRIPTION
## Description

In an ID-list election, the voter-ID field renders in its **error state with "Invalid Voter ID" from the moment the page loads** — before the voter has typed a character.

**Cause:** `VoterAuth.tsx:47` tests `voterAuth?.required === "Voter ID Required"`, but the backend (`voterRollUtils.ts` `getMissingAuthData`) returns `"Voter ID Required for closed elections"`. The comparison never matches, so `missingVoterID` is always `false`, and the error branch `(!missingVoterID && !isAuthorized)` is true on first paint.

**Fix:** compare against the string the backend actually sends. One line, frontend side — the backend string may appear in logs, so the compare is the safer end to change. The sibling check (`"Email Validation Required"`) already matches its backend string exactly, which is how this drifted unnoticed: one of the two worked.

After the fix the field starts neutral, and the error appears only after a submitted ID actually fails.

**Longer-term** these magic-string comparisons would be safer as shared constants or an enum on the auth response — happy to do that as a follow-up if wanted; this PR is the minimal behaviour fix.

## Screenshots / Videos (frontend only)

Behaviour fix visible in any ID-list election: before, the field is red with "Invalid Voter ID" on load; after, it is neutral until a wrong ID is submitted.

## Related Issues

Found while writing the voter troubleshooting help page (#1550, indexed in #1556).