### PR TITLE
fix(emails): "update you ballot" → "update your ballot" in the receipt

### DIFF
--- a/packages/backend/src/Services/Email/EmailTemplates.ts
+++ b/packages/backend/src/Services/Email/EmailTemplates.ts
@@ -96,7 +96,7 @@ export function Receipt(election: Election, email: string, ballot: Ballot, url: 
         from: process.env.FROM_EMAIL_ADDRESS ?? '',
         subject: `Ballot Receipt For ${election.title}`,
         text: `${election.state === 'draft' ? '[⚠️Test Ballot]' : ''} Thank you for voting in ${election.title}, you can view your ballot and ballot status at \
-               ${ballotVerifyUrl}. ${election.settings.ballot_updates && roll ? `While the election is still open, you can update you ballot at ${ballotUpdateUrl}`: ''}`,
+               ${ballotVerifyUrl}. ${election.settings.ballot_updates && roll ? `While the election is still open, you can update your ballot at ${ballotUpdateUrl}`: ''}`,
         html: emailTemplate(`
           <div> 
             ${election.state === 'draft' ? "<h3>⚠️This was cast as a test ballot. All test ballots will be removed once the election is finalized, and at that time you will need to vote again.⚠️</h3>" : ''}


### PR DESCRIPTION
## Description

The plaintext ballot receipt reads *"While the election is still open, you can update **you** ballot at …"* (`EmailTemplates.ts:99`).

One character — but it sits in the sentence that hands the voter their vote-changing link, the most trust-sensitive line either template contains. Only the plaintext variant is affected; the HTML variant already says "your".

## Screenshots / Videos (frontend only)

n/a — backend email template.

## Related Issues

Found during the documentation program in #1556.