### PR TITLE
Race-prefix overvote_rank/has_duplicate_rank in the ballot CSV export

### DIFF
--- a/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
+++ b/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
@@ -46,9 +46,18 @@ export const BallotDataExport = ({ election, results }: Props) => {
                     label: election.races.length == 1 ? c.candidate_name : `${race.title}!!${c.candidate_name}`,
                     key: `${race.race_id}-${c.candidate_id}`,
                 })),
+                // Race-prefixed like the candidate columns above: with multiple races,
+                // unprefixed labels collide and the keys would make every race's column
+                // show the last ranked race's values.
                 ...((race.voting_method == 'IRV' || race.voting_method == 'STV') ? [
-                    { label: 'overvote_rank', key: 'overvote_rank' },
-                    { label: 'has_duplicate_rank', key: 'has_duplicate_rank' },
+                    {
+                        label: election.races.length == 1 ? 'overvote_rank' : `${race.title}!!overvote_rank`,
+                        key: `${race.race_id}-overvote_rank`,
+                    },
+                    {
+                        label: election.races.length == 1 ? 'has_duplicate_rank' : `${race.title}!!has_duplicate_rank`,
+                        key: `${race.race_id}-has_duplicate_rank`,
+                    },
                 ] : []),
             ]),
         ].flat();
@@ -66,8 +75,8 @@ export const BallotDataExport = ({ election, results }: Props) => {
                 });
                 const race = election.races.find((r) => r.race_id == vote.race_id);
                 if (race && (race.voting_method == 'IRV' || race.voting_method == 'STV')) {
-                    row['overvote_rank'] = vote.overvote_rank ?? '';
-                    row['has_duplicate_rank'] = vote.has_duplicate_rank ? 'TRUE' : 'FALSE';
+                    row[`${vote.race_id}-overvote_rank`] = vote.overvote_rank ?? '';
+                    row[`${vote.race_id}-has_duplicate_rank`] = vote.has_duplicate_rank ? 'TRUE' : 'FALSE';
                 }
             });
             return row;


### PR DESCRIPTION
## Description

In the ballot-data CSV export (`BallotDataExport.tsx`), the per-candidate columns are race-prefixed (`Race!!Candidate`), but the ranked-ballot bookkeeping columns `overvote_rank` and `has_duplicate_rank` were not. With two or more IRV/STV races on one ballot, the header emitted the same unprefixed label **and key** once per ranked race, and the row builder wrote every race's values into the same two keys — so the **last** ranked race's values were repeated under **every** race's columns. An auditor reading a multi-race export got wrong per-race data with no warning.

Concretely, for a two-race election (Mayor = IRV, Council = STV) where ballot `b1` has an overvote at rank 2 in **Mayor** and ballot `b2` has a duplicate rank in **Council**:

**Before** (Mayor's columns silently show Council's values; b1's real overvote is erased, b2 is falsely flagged with a duplicate in Mayor):

```
ballot_id,precinct,Mayor!!Ada,Mayor!!Ben,overvote_rank,has_duplicate_rank,Council!!Cara,Council!!Dan,overvote_rank,has_duplicate_rank
b1,P1,1,2,,FALSE,1,2,,FALSE
b2,P1,2,1,,TRUE,1,1,,TRUE
```

**After**:

```
ballot_id,precinct,Mayor!!Ada,Mayor!!Ben,Mayor!!overvote_rank,Mayor!!has_duplicate_rank,Council!!Cara,Council!!Dan,Council!!overvote_rank,Council!!has_duplicate_rank
b1,P1,1,2,2,FALSE,1,2,,FALSE
b2,P1,2,1,,FALSE,1,1,,TRUE
```

### The fix, and the compatibility choice

The two columns are now scoped per race **exactly the way the candidate columns already are**:

- **Row keys** always carry the race id (`${race.race_id}-overvote_rank`), mirroring the candidate keys (`${race.race_id}-${candidate_id}`) — keys are internal, so this has no effect on the file itself.
- **Header labels** take the `${race.title}!!` prefix under the **same condition the candidate labels use**: `election.races.length > 1`. I considered prefixing only when the election has more than one *ranked* race (maximally conservative for existing consumers), but followed the codebase's own convention instead: the candidate columns key their prefixing on the total race count, and a mixed election (one ranked race among several) already prefixes every candidate column, so leaving two bare bookkeeping columns floating among prefixed ones is the inconsistent — and ambiguous — reading. Multi-race exports of these two columns were wrong or ambiguous before, so no correct consumer behavior is being broken there.
- **Single-race exports are byte-identical** to today's output (verified in the harness below), so the common case keeps full backward compatibility.

### Verification

The frontend package has no test runner configured, so I verified with a standalone harness that replicates the export's header/row assembly for the two-race election above, before and after. Assertions (all passing): headers are unique; b1's Mayor `overvote_rank` = 2; b1's Council `has_duplicate_rank` = FALSE; b2's Mayor `overvote_rank` blank and `has_duplicate_rank` = FALSE; b2's Council `has_duplicate_rank` = TRUE; and a single-race election's export is byte-identical before vs after.

`npx tsc --noEmit` passes in `packages/frontend`.

Also checked for in-repo consumers of this export: the CVR importer (`UploadElections.tsx` / `cvrParsers.tsx`) reads a different `rank1,rank2,…` column format, not this file, and no docs or tests assert the old header layout.

## Screenshots / Videos (frontend only)

No visual change — the export file contents change as shown in the before/after headers above.

## Related Issues

Part of the ballot-data export bug list in #1556. Note for docs: the exporting-data help page written under #1545 deliberately avoided asserting that `overvote_rank` / `has_duplicate_rank` are per-race scoped because of this bug — once this merges, that page can be tightened to state the per-race scoping outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
