### PR TITLE
Enforce max_rankings on the draggable RCV ballot

### DIFF
--- a/packages/frontend/src/components/Election/Voting/DraggableIRVBallotView.tsx
+++ b/packages/frontend/src/components/Election/Voting/DraggableIRVBallotView.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useMemo, useState } from 'react';
-import { Box, Paper, Typography, FormGroup, FormControlLabel, Checkbox } from '@mui/material';
+import { Alert, Box, Paper, Typography, FormGroup, FormControlLabel, Checkbox } from '@mui/material';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import { BallotContext } from './VotePage';
-import { useSubstitutedTranslation } from '~/components/util';
+import { getMaxRankings, useSubstitutedTranslation } from '~/components/util';
 import useElection from '../../ElectionContextProvider';
 import { BallotCandidate } from './VotePage';
 import { FormattedDescription } from '~/components/FormattedDescription';
@@ -56,6 +56,20 @@ export default function DraggableIRVBallotView() {
 
   const rankedIds = useMemo(() => rankedCandidates.map(c => c.candidate_id.toString()), [rankedCandidates]);
 
+  // The ranking limit the server validates against (shared/src/domain_model/Ballot.ts
+  // rejects scores above max_rankings) — resolved exactly like the classic ranked
+  // ballot resolves its number of rank columns, and never more than the number of
+  // candidates on this ballot.
+  const maxRankings = useMemo(
+    () => Math.min(getMaxRankings(ballotContext.maxRankings), ballotContext.candidates.length),
+    [ballotContext.maxRankings, ballotContext.candidates.length]
+  );
+
+  // Set when a drop was refused because the ranking limit was reached; the alert
+  // hides itself again once the voter removes a candidate from their rankings.
+  const [limitHit, setLimitHit] = useState(false);
+  const showLimitAlert = limitHit && rankedCandidates.length >= maxRankings;
+
   // Track display order of unranked candidates independently so reordering is preserved
   const [unrankedOrder, setUnrankedOrder] = useState<string[]>(() =>
     ballotContext.candidates
@@ -82,6 +96,15 @@ export default function DraggableIRVBallotView() {
     const from = source.droppableId;
     const to = destination.droppableId;
     const id = draggableId;
+
+    // Refuse a drop that would rank more candidates than the election allows —
+    // the server would reject the ballot (Ballot.ts caps scores at max_rankings).
+    // Reordering within the ranked list stays allowed.
+    if (to === 'ranked' && from !== 'ranked' && rankedIds.length >= maxRankings) {
+      setLimitHit(true);
+      return;
+    }
+    setLimitHit(false);
 
     // update unranked order
     setUnrankedOrder(prev => {
@@ -224,6 +247,9 @@ export default function DraggableIRVBallotView() {
           <Box sx={{ minWidth: 0 }}>
             <Typography variant="h6" gutterBottom>
               {t('ballot.yourRankings', 'Your Rankings')}
+              <Typography component="span" variant="body2" sx={{ color: 'text.secondary', ml: 1 }}>
+                {t('ballot.rankings_used', { n: rankedCandidates.length, max: maxRankings })}
+              </Typography>
             </Typography>
             <Droppable droppableId="ranked">
               {(provided, snapshot) => (
@@ -292,6 +318,11 @@ export default function DraggableIRVBallotView() {
                 </Paper>
               )}
             </Droppable>
+            {showLimitAlert && (
+              <Alert severity="warning" sx={{ mt: 1 }}>
+                {t('ballot.max_rankings_reached', { max: maxRankings })}
+              </Alert>
+            )}
           </Box>
         </Box>
       </Box>

--- a/packages/frontend/src/components/Election/Voting/RankedBallotView.tsx
+++ b/packages/frontend/src/components/Election/Voting/RankedBallotView.tsx
@@ -2,7 +2,7 @@ import { useContext, useMemo, useCallback } from 'react';
 import { BallotContext } from './VotePage';
 import GenericBallotView from './GenericBallotView/GenericBallotView';
 import DraggableIRVBallotView from './DraggableIRVBallotView';
-import { useSubstitutedTranslation } from '~/components/util';
+import { getMaxRankings, useSubstitutedTranslation } from '~/components/util';
 import useElection from '../../ElectionContextProvider'; 
 
 
@@ -10,12 +10,6 @@ export default function RankedBallotView({ onlyGrid = false }: { onlyGrid?: bool
   const ballotContext = useContext(BallotContext);
   const { election } = useElection();
   const { t } = useSubstitutedTranslation();
-
-  // Use draggable component for IRV when draggable_ballot setting is enabled
-  if (ballotContext.race.voting_method === 'IRV' && election.settings.draggable_ballot && !onlyGrid) {
-    return <DraggableIRVBallotView />;
-  }
-
 
   // disabling warnings until we have a better solution, see slack convo
   // https://starvoting.slack.com/archives/C01EBAT283H/p1677023113477139
@@ -28,15 +22,7 @@ export default function RankedBallotView({ onlyGrid = false }: { onlyGrid?: bool
   //   )
   //  }  
 
-  const maxRankings = useMemo(() => {
-    const MAX_BALLOT_RANKS = Number(process.env.REACT_APP_MAX_BALLOT_RANKS) ? Number(process.env.REACT_APP_MAX_BALLOT_RANKS) : 8;
-    const DEFAULT_BALLOT_RANKS = Number(process.env.REACT_APP_DEFAULT_BALLOT_RANKS) ? Number(process.env.REACT_APP_DEFAULT_BALLOT_RANKS) : 6;
-    if (ballotContext.maxRankings) {
-      return Math.min(ballotContext.maxRankings, MAX_BALLOT_RANKS);
-    } else {
-      return DEFAULT_BALLOT_RANKS;
-    }
-  }, [ballotContext.maxRankings]);
+  const maxRankings = useMemo(() => getMaxRankings(ballotContext.maxRankings), [ballotContext.maxRankings]);
   const findSkippedColumns = useCallback((scores: number[]): number[] | undefined => {
     const skippedColumns: number[] = [];
     for (let i = 1; i <= maxRankings; i++) {
@@ -107,6 +93,15 @@ export default function RankedBallotView({ onlyGrid = false }: { onlyGrid?: bool
   const columns = useMemo(() => {
     return columnValues.map(v => t('number.rank', { count: v, ordinal: true }));
   }, [columnValues, t]);
+
+  // Use draggable component for IRV when draggable_ballot setting is enabled.
+  // NOTE: this early return must come after all the hooks above — when a voter
+  // pages between a draggable IRV race and another ranked race in the same
+  // election, this component re-renders with the other race, and returning
+  // before the hooks would change the hook count between renders and crash.
+  if (ballotContext.race.voting_method === 'IRV' && election.settings.draggable_ballot && !onlyGrid) {
+    return <DraggableIRVBallotView />;
+  }
 
   return (
     <GenericBallotView

--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -86,6 +86,20 @@ export function hashString(inputString: string) {
     return createHash('sha256').update(inputString).digest('hex')
 }
 
+// Resolves the number of rankings a voter may use on a ranked ballot.
+// Mirrors the semantics the server validates against (shared/src/domain_model/Ballot.ts
+// rejects scores above election.settings.max_rankings): the election's max_rankings
+// setting capped at REACT_APP_MAX_BALLOT_RANKS (default 8), falling back to
+// REACT_APP_DEFAULT_BALLOT_RANKS (default 6) when the setting is unset.
+export const getMaxRankings = (maxRankingsSetting?: number): number => {
+  const MAX_BALLOT_RANKS = Number(process.env.REACT_APP_MAX_BALLOT_RANKS) ? Number(process.env.REACT_APP_MAX_BALLOT_RANKS) : 8;
+  const DEFAULT_BALLOT_RANKS = Number(process.env.REACT_APP_DEFAULT_BALLOT_RANKS) ? Number(process.env.REACT_APP_DEFAULT_BALLOT_RANKS) : 6;
+  if (maxRankingsSetting) {
+    return Math.min(maxRankingsSetting, MAX_BALLOT_RANKS);
+  }
+  return DEFAULT_BALLOT_RANKS;
+}
+
 export const formatPercent = (f: number): string => {
   if(0 < f && f < .01) return '<1%';
   return `${Math.round(100*f)}%`

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -53,6 +53,8 @@ ballot:
   no_available: No available candidates
   instructions: Drag candidates from the left to the right list. Candidates on the right are your ranked order; left means unranked.
   instructions_rcv_draggable: Drag candidates left → right. Rank 1 is your top choice. Unranked means no preference.
+  rankings_used: '{{n}} of {{max}} rankings used'
+  max_rankings_reached: You can rank up to {{max}} candidates on this ballot. To rank this candidate, first drag another one out of your rankings.
 
   dialog_submit_title: Submit {{capital_ballot}}?
   dialog_send_receipt: Send Ballot Receipt Email?


### PR DESCRIPTION
## Description

The draggable ranked (RCV) ballot ignored the election's `max_rankings` setting: a voter could drag any number of candidates into "Your Rankings", and only found out at submit time, when server-side validation rejected the ballot they had just built — with no hint while they were building it.

**Where the cap was missing:** `packages/frontend/src/components/Election/Voting/DraggableIRVBallotView.tsx` — `onDragEnd` (lines ~78–104 on `main`) committed a rank for every candidate dropped into the ranked list, with no limit check.

**What the server enforces:** `packages/shared/src/domain_model/Ballot.ts` line 84 reads `election.settings.max_rankings`, and lines 116–124 reject any ranked-method score above it ("Scores out of bounds").

**How the classic ranked ballot already enforces it:** `packages/frontend/src/components/Election/Voting/RankedBallotView.tsx` (lines 31–39 on `main`) resolves the limit — `min(max_rankings, REACT_APP_MAX_BALLOT_RANKS ?? 8)`, defaulting to `REACT_APP_DEFAULT_BALLOT_RANKS ?? 6` when unset — and only renders that many rank columns (`candidates.slice(0, maxRankings)`, line ~104), so exceeding the limit is impossible there.

### Changes

- Extracted the classic ballot's limit resolution into `getMaxRankings()` in `packages/frontend/src/components/util.tsx`, used by both ranked ballot views, so the two views (and the served-side rule they mirror) cannot drift.
- `DraggableIRVBallotView` now refuses a drop into "Your Rankings" once the limit is reached — the candidate stays in "Available Candidates" and a warning `Alert` explains the limit (it clears when the voter frees up a slot or performs another drag). Reordering within the rankings and removing candidates remain allowed at the limit.
- Added an "N of M rankings used" counter beside the "Your Rankings" heading, the draggable equivalent of the classic view's visible column count.
- Two new i18n strings in the ballot section of `en.yaml` (`ballot.rankings_used`, `ballot.max_rankings_reached`); other locales fall back to English.
- Moved `RankedBallotView`'s draggable early-return below its hooks. It previously returned before them, so paging from a draggable IRV race to another ranked race in the same election changed the hook count between renders and crashed React ("Rendered more hooks than during the previous render" — white page). Found while verifying this fix on a multi-race election.

No server-side validation was changed.

## Screenshots / Videos (frontend only)

No screenshots attached; verified manually as described below. The counter renders as grey text after the "Your Rankings" heading ("0 of 6 rankings used"), and the refusal shows a standard MUI warning alert under the rankings list: *"You can rank up to 6 candidates on this ballot. To rank this candidate, first drag another one out of your rankings."*

**Manual verification** (local dev server against the production API, election `cxrf8v`, 5 candidates, with the limit temporarily lowered to 3 locally to make it reachable):

- Dragging a 4th candidate into "Your Rankings" is refused: the candidate stays in "Available Candidates", the alert appears, the counter stays at "3 of 3 rankings used".
- Reordering within "Your Rankings" while at the limit still works.
- Dragging a ranked candidate back out updates the counter to "2 of 3" and hides the alert; ranking a different candidate up to the limit works again with no spurious alert.
- Keyboard drag-and-drop (space / arrows) goes through the same `onDragEnd`, so it is covered by the same guard.
- Paging from the draggable IRV race to the election's Ranked Robin race and back no longer white-screens (the hooks fix).

`npx tsc --noEmit` passes in `packages/frontend`; `eslint` reports no new issues in the touched files (the frontend has no test suite or Storybook to extend).

## Related Issues

Part of the draggable-ballot bug list in #1556 (draggable ranked ballot does not respect the maximum-rankings limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
