### PR TITLE
Add Dependabot version updates with grouped minor/patch PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,92 @@
+# Dependabot version updates.
+#
+# Minor and patch bumps are grouped into a single PR per ecosystem to keep
+# review overhead low. Major bumps are deliberately left ungrouped so each one
+# gets its own PR and a real review.
+#
+# A cooldown holds brand-new releases for a few days, which blunts compromised-
+# release supply-chain attacks. Only semver ecosystems accept semver-*-days;
+# docker, docker-compose, github-actions, terraform and pip take default-days
+# alone and are rejected outright if given the semver keys.
+#
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+
+updates:
+
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /testing
+      - /.github/scripts
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      npm:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: bundler
+    directory: /docs
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      bundler:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directories:
+      - /
+      - /testing
+      - /.sandcastle
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      docker:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      docker-compose:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds a Dependabot config so this repo gets **scheduled version updates**, not just security-advisory PRs.

There was no `.github/dependabot.yml` here, which means Dependabot has only ever opened PRs in response to security alerts. Routine dependency drift has gone untracked.

## Coverage

| Ecosystem | Directories |
| --- | --- |
| `npm` | `/`, `/testing`, `/.github/scripts` |
| `bundler` | `/docs` |
| `docker` | `/`, `/testing`, `/.sandcastle` |
| `docker-compose` | `/` |
| `github-actions` | `/` |

## Grouping

Minor and patch bumps are collected into **one grouped PR per ecosystem**, weekly. Major bumps are deliberately left ungrouped so each arrives as its own PR and gets a real review.

## Cooldown

New releases are held before Dependabot proposes them, which blunts compromised-release supply-chain attacks where a malicious version is published and yanked within hours.

Only ecosystems Dependabot treats as semver accept graduated holds (3 days patch / 7 minor / 30 major). `docker`, `docker-compose`, `github-actions`, `terraform` and `pip` accept `default-days` alone and are **rejected outright** if given the semver keys, so those entries carry a flat 7-day hold.

Security-advisory PRs are driven by Dependabot alerts rather than this schedule, so urgent fixes are not delayed by it.

Heads up: the first run after merge will open a burst of PRs covering accumulated drift. That settles to roughly one PR per ecosystem per week; `open-pull-requests-limit: 10` caps it meanwhile.

Part of an org-wide pass adding this config to all Equal-Vote repos with a package manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpZM2dqedR4fXiLn7272XQ
