### PR TITLE
Group Dependabot security-advisory PRs per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@
 # docker, docker-compose, github-actions, terraform and pip take default-days
 # alone and are rejected outright if given the semver keys.
 #
+# A group only covers security-advisory PRs if it sets
+# `applies-to: security-updates` -- a group without that key defaults to
+# version updates alone, which leaves advisories arriving one PR per advisory.
+# The *-security groups below bundle them per ecosystem. Those deliberately
+# include majors: declining a security fix because it is a major bump is not a
+# real option.
+#
 # Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
 version: 2
 
@@ -32,6 +39,10 @@ updates:
         update-types:
           - minor
           - patch
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: bundler
     directory: /docs
@@ -48,6 +59,10 @@ updates:
         update-types:
           - minor
           - patch
+      bundler-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directories:
@@ -64,6 +79,10 @@ updates:
         update-types:
           - minor
           - patch
+      docker-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: docker-compose
     directory: /
@@ -77,6 +96,10 @@ updates:
         update-types:
           - minor
           - patch
+      docker-compose-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
@@ -90,3 +113,7 @@ updates:
         update-types:
           - minor
           - patch
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Groups Dependabot's **security-advisory** PRs, which the existing config does not cover.

A `groups` entry without `applies-to` defaults to `version-updates` only. So while minor/patch *version* updates have been arriving grouped since the last PR merged, security advisories still open **one PR per advisory**. This adds a second group per ecosystem that sets `applies-to: security-updates`.

## Groups after this change

| Ecosystem | Version updates | Security updates |
| --- | --- | --- |
| `npm` | `npm` | `npm-security` |
| `bundler` | `bundler` | `bundler-security` |
| `docker` | `docker` | `docker-security` |
| `docker-compose` | `docker-compose` | `docker-compose-security` |
| `github-actions` | `github-actions` | `github-actions-security` |

## Notes

- The security groups use `patterns: ["*"]`, so they **include major bumps**. That is deliberate — declining a security fix on the grounds that it is a major version bump is not a real option.
- This only affects PRs opened from the merge onward. Security PRs already open are not retroactively grouped and still need merging or closing by hand.
- Cooldown is untouched. Security updates are driven by Dependabot alerts, so urgent fixes are not delayed by the version-update schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpZM2dqedR4fXiLn7272XQ
